### PR TITLE
Add missing functions for MockRedis

### DIFF
--- a/arq/testing.py
+++ b/arq/testing.py
@@ -100,8 +100,16 @@ class MockRedis:
         self.data[key] = value
         self._expiry[key] = datetime.now() + timedelta(seconds=expires)
 
+    async def expire(self, key, expires):
+        self._expiry[key] = datetime.now() + timedelta(seconds=expires)
+
     async def get(self, key):
         return self._get(key)
+
+    async def getset(self, key, value):
+        old_value = self._get(key)
+        await self.set(key, value)
+        return old_value
 
     def close(self):
         pass

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,6 +37,14 @@ def test_arbitrary_logger(capsys):
     assert [out, err] == ['this is a test\n', '']
 
 
+async def test_mock_redis_getset(loop):
+    r = MockRedis(loop=loop)
+    await r.set('foo', 'bar')
+    assert 'bar' == await r.get('foo')
+    assert 'bar' == await r.getset('foo', 'baz')
+    assert 'baz' == await r.get('foo')
+
+
 async def test_mock_redis_expiry_ok(loop):
     r = MockRedis(loop=loop)
     await r.setex('foo', 10, 'bar')
@@ -46,6 +54,13 @@ async def test_mock_redis_expiry_ok(loop):
 async def test_mock_redis_expiry_expired(loop):
     r = MockRedis(loop=loop)
     await r.setex('foo', -10, 'bar')
+    assert None is await r.get('foo')
+
+
+async def test_mock_redis_expire_expired(loop):
+    r = MockRedis(loop=loop)
+    await r.set('foo', 'bar')
+    await r.expire('foo', -10)
     assert None is await r.get('foo')
 
 


### PR DESCRIPTION
I tried to use MockRedis for unit tests and found out that there are no implementation for some functions.