### PR TITLE
Feat worker limit

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.17.0 (unreleased)
+....................
+* add ``worker.queue_read_limit``, fix #141, by @rubik
+
 v0.16.1 (2019-08-02)
 ....................
 * prevent duplicate ``job_id`` when job result exists, fix #137

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -138,7 +138,8 @@ class Worker:
     :param job_timeout: default job timeout (max run time)
     :param keep_result: default duration to keep job results for
     :param poll_delay: duration between polling the queue for new jobs
-    :param queue_read_limit: the maximum number of jobs to pull from the queue each time it's polled; by default it equals ``max_jobs``
+    :param queue_read_limit: the maximum number of jobs to pull from the queue each time it's polled; by default it
+                             equals ``max_jobs``
     :param max_tries: default maximum number of times to retry a job
     :param health_check_interval: how often to set the health check key
     :param health_check_key: redis key under which health check is set

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -185,9 +185,7 @@ class Worker:
         self.job_timeout_s = to_seconds(job_timeout)
         self.keep_result_s = to_seconds(keep_result)
         self.poll_delay_s = to_seconds(poll_delay)
-        self.queue_read_limit = queue_read_limit
-        if self.queue_read_limit is None:
-            self.queue_read_limit = max_jobs
+        self.queue_read_limit = queue_read_limit or max_jobs
         self._queue_read_offset = 0
         self.max_tries = max_tries
         self.health_check_interval = to_seconds(health_check_interval)

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -278,12 +278,6 @@ class Worker:
                 queued_jobs = await self.pool.zcard(self.queue_name)
                 if queued_jobs == 0:
                     return
-            async with self.sem:  # don't bother with zrangebyscore until we have "space" to run the jobs
-                now = timestamp_ms()
-                job_ids = await self.pool.zrangebyscore(
-                    self.queue_name, offset=self._queue_read_offset, count=self.queue_read_limit, max=now
-                )
-            await self.run_jobs(job_ids)
 
     async def _poll_iteration(self):
         async with self.sem:  # don't bother with zrangebyscore until we have "space" to run the jobs

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -271,7 +271,7 @@ class Worker:
             async with self.sem:  # don't bother with zrangebyscore until we have "space" to run the jobs
                 now = timestamp_ms()
                 job_ids = await self.pool.zrangebyscore(
-                    self.queue_name, offset=self.queue_read_offset, count=self.queue_read_limit, max=now,
+                    self.queue_name, offset=self.queue_read_offset, count=self.queue_read_limit, max=now
                 )
             await self.run_jobs(job_ids)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,9 +18,9 @@ async def arq_redis(loop):
 async def worker(arq_redis):
     worker_: Worker = None
 
-    def create(functions=[], burst=True, poll_delay=0, **kwargs):
+    def create(functions=[], burst=True, poll_delay=0, queue_read_limit=40, **kwargs):
         nonlocal worker_
-        worker_ = Worker(functions=functions, redis_pool=arq_redis, burst=burst, poll_delay=poll_delay, **kwargs)
+        worker_ = Worker(functions=functions, redis_pool=arq_redis, burst=burst, poll_delay=poll_delay, queue_read_limit=queue_read_limit, **kwargs)
         return worker_
 
     yield create

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,14 +18,14 @@ async def arq_redis(loop):
 async def worker(arq_redis):
     worker_: Worker = None
 
-    def create(functions=[], burst=True, poll_delay=0, queue_read_limit=40, **kwargs):
+    def create(functions=[], burst=True, poll_delay=0, max_jobs=10, **kwargs):
         nonlocal worker_
         worker_ = Worker(
             functions=functions,
             redis_pool=arq_redis,
             burst=burst,
             poll_delay=poll_delay,
-            queue_read_limit=queue_read_limit,
+            max_jobs=max_jobs,
             **kwargs,
         )
         return worker_

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,12 +21,7 @@ async def worker(arq_redis):
     def create(functions=[], burst=True, poll_delay=0, max_jobs=10, **kwargs):
         nonlocal worker_
         worker_ = Worker(
-            functions=functions,
-            redis_pool=arq_redis,
-            burst=burst,
-            poll_delay=poll_delay,
-            max_jobs=max_jobs,
-            **kwargs,
+            functions=functions, redis_pool=arq_redis, burst=burst, poll_delay=poll_delay, max_jobs=max_jobs, **kwargs
         )
         return worker_
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,14 @@ async def worker(arq_redis):
 
     def create(functions=[], burst=True, poll_delay=0, queue_read_limit=40, **kwargs):
         nonlocal worker_
-        worker_ = Worker(functions=functions, redis_pool=arq_redis, burst=burst, poll_delay=poll_delay, queue_read_limit=queue_read_limit, **kwargs)
+        worker_ = Worker(
+            functions=functions,
+            redis_pool=arq_redis,
+            burst=burst,
+            poll_delay=poll_delay,
+            queue_read_limit=queue_read_limit,
+            **kwargs,
+        )
         return worker_
 
     yield create

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -26,6 +26,7 @@ def test_no_jobs(arq_redis: ArqRedis, loop):
         functions = [func(foobar, name='foobar')]
         burst = True
         poll_delay = 0
+        queue_read_limit = 10
 
     loop.run_until_complete(arq_redis.enqueue_job('foobar'))
     worker = run_worker(Settings)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -458,7 +458,6 @@ async def test_queue_read_limit_equals_max_jobs(arq_redis: ArqRedis, worker):
 
     assert await arq_redis.zcard(default_queue_name) == 4
     worker: Worker = worker(functions=[foobar], max_jobs=2)
-    worker.pool = await create_pool(worker.redis_settings)
     assert worker.jobs_complete == 0
     assert worker.jobs_failed == 0
     assert worker.jobs_retried == 0
@@ -484,7 +483,6 @@ async def test_custom_queue_read_limit(arq_redis: ArqRedis, worker):
 
     assert await arq_redis.zcard(default_queue_name) == 4
     worker: Worker = worker(functions=[foobar], max_jobs=4, queue_read_limit=2)
-    worker.pool = await create_pool(worker.redis_settings)
     assert worker.jobs_complete == 0
     assert worker.jobs_failed == 0
     assert worker.jobs_retried == 0

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -9,7 +9,7 @@ import msgpack
 import pytest
 from aioredis import create_redis_pool
 
-from arq.connections import ArqRedis, create_pool
+from arq.connections import ArqRedis
 from arq.constants import default_queue_name, health_check_key_suffix, job_key_prefix
 from arq.jobs import Job, JobStatus, SerializationError
 from arq.worker import FailedJobs, JobExecutionFailed, Retry, Worker, async_check_health, check_health, func, run_worker

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -488,14 +488,14 @@ async def test_custom_queue_read_limit(arq_redis: ArqRedis, worker):
     assert worker.jobs_retried == 0
 
     await worker._poll_iteration()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.1)
     assert await arq_redis.zcard(default_queue_name) == 2
     assert worker.jobs_complete == 2
     assert worker.jobs_failed == 0
     assert worker.jobs_retried == 0
 
     await worker._poll_iteration()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.1)
     assert await arq_redis.zcard(default_queue_name) == 0
     assert worker.jobs_complete == 4
     assert worker.jobs_failed == 0

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -465,14 +465,14 @@ async def test_queue_read_limit_equals_max_jobs(arq_redis: ArqRedis, worker):
     assert worker.jobs_retried == 0
 
     await worker._poll_iteration()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.1)
     assert await arq_redis.zcard(default_queue_name) == 2
     assert worker.jobs_complete == 2
     assert worker.jobs_failed == 0
     assert worker.jobs_retried == 0
 
     await worker._poll_iteration()
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.1)
     assert await arq_redis.zcard(default_queue_name) == 0
     assert worker.jobs_complete == 4
     assert worker.jobs_failed == 0


### PR DESCRIPTION
This PR adds a new parameter to the `Worker` class: `queue_read_limit`. It allows limiting the number of job IDs that are read from the queue at each polling interval.

Redis requires to set both `offset` and `count`, so I've added another instance attribute called `queue_read_offset` that sets the offset to 0 in case `queue_read_limit` is specified, and to `None` otherwise. I haven't added a corresponding parameter for this attribute because I think that in the majority of the cases it's not needed. I think it could be useful to investigate it in case multiple workers are run in parallel, but I haven't tested this so I refrained from complicating the public interface further.

This PR passes all tests except two, which also fail in the `master` branch. So they are most likely unrelated to these changes.

Fixes #141 