### PR TITLE
Custom serializers

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.17 (unreleased)
+..................
+* custom serializers, eg. to use msgpack rather than pickle, #143 by @rubik
+
 v0.16.1 (2019-08-02)
 ....................
 * prevent duplicate ``job_id`` when job result exists, fix #137

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -186,7 +186,7 @@ async def create_pool(
 
     # recursively attempt to create the pool outside the except block to avoid
     # "During handling of the above exception..." madness
-    return await create_pool(settings, _retry=_retry + 1)
+    return await create_pool(settings, retry=_retry + 1, _job_serializer=_job_serializer, _job_deserializer=_job_deserializer)
 
 
 async def log_redis_info(redis, log_func):

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -4,14 +4,14 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from operator import attrgetter
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, List, Optional, Union
 from uuid import uuid4
 
 import aioredis
 from aioredis import MultiExecError, Redis
 
 from .constants import default_queue_name, job_key_prefix, result_key_prefix
-from .jobs import Job, JobResult, serialize_job
+from .jobs import Serializer, Deserializer, Job, JobResult, serialize_job
 from .utils import timestamp_ms, to_ms, to_unix_ms
 
 logger = logging.getLogger('arq.connections')
@@ -54,8 +54,8 @@ class ArqRedis(Redis):
     def __init__(
         self,
         pool_or_conn,
-        _job_serializer: Optional[Callable[[Any], bytes]] = None,
-        _job_deserializer: Optional[Callable[[bytes], Any]] = None,
+        _job_serializer: Optional[Serializer] = None,
+        _job_deserializer: Optional[Deserializer] = None,
         **kwargs,
     ) -> None:
         self._job_serializer = _job_serializer
@@ -146,8 +146,8 @@ async def create_pool(
     settings: RedisSettings = None,
     *,
     _retry: int = 0,
-    _job_serializer: Optional[Callable[[Any], bytes]] = None,
-    _job_deserializer: Optional[Callable[[bytes], Any]] = None,
+    _job_serializer: Optional[Serializer] = None,
+    _job_deserializer: Optional[Deserializer] = None,
 ) -> ArqRedis:
     """
     Create a new redis pool, retrying up to ``conn_retries`` times if the connection fails.

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -11,7 +11,7 @@ import aioredis
 from aioredis import MultiExecError, Redis
 
 from .constants import default_queue_name, job_key_prefix, result_key_prefix
-from .jobs import Serializer, Deserializer, Job, JobResult, serialize_job
+from .jobs import Deserializer, Job, JobResult, Serializer, serialize_job
 from .utils import timestamp_ms, to_ms, to_unix_ms
 
 logger = logging.getLogger('arq.connections')
@@ -164,7 +164,9 @@ async def create_pool(
             password=settings.password,
             timeout=settings.conn_timeout,
             encoding='utf8',
-            commands_factory=functools.partial(ArqRedis, _job_serializer=job_serializer, _job_deserializer=job_deserializer),
+            commands_factory=functools.partial(
+                ArqRedis, _job_serializer=job_serializer, _job_deserializer=job_deserializer
+            ),
         )
     except (ConnectionError, OSError, aioredis.RedisError, asyncio.TimeoutError) as e:
         if retry < settings.conn_retries:
@@ -186,7 +188,9 @@ async def create_pool(
 
     # recursively attempt to create the pool outside the except block to avoid
     # "During handling of the above exception..." madness
-    return await create_pool(settings, retry=retry + 1, job_serializer=job_serializer, job_deserializer=job_deserializer)
+    return await create_pool(
+        settings, retry=retry + 1, job_serializer=job_serializer, job_deserializer=job_deserializer
+    )
 
 
 async def log_redis_info(redis, log_func):

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -115,7 +115,7 @@ class ArqRedis(Redis):
 
             expires_ms = expires_ms or score - enqueue_time_ms + expires_extra_ms
 
-            job = serialize_job(function, args, kwargs, _job_try, enqueue_time_ms, _serialize=self._job_serializer)
+            job = serialize_job(function, args, kwargs, _job_try, enqueue_time_ms, serializer=self._job_serializer)
             tr = conn.multi_exec()
             tr.psetex(job_key, expires_ms, job)
             tr.zadd(_queue_name, score, job_id)
@@ -124,11 +124,11 @@ class ArqRedis(Redis):
             except MultiExecError:
                 # job got enqueued since we checked 'job_exists'
                 return
-        return Job(job_id, redis=self, _deserialize=self._job_deserializer)
+        return Job(job_id, redis=self, _deserializer=self._job_deserializer)
 
     async def _get_job_result(self, key):
         job_id = key[len(result_key_prefix) :]
-        job = Job(job_id, self, _deserialize=self._job_deserializer)
+        job = Job(job_id, self, _deserializer=self._job_deserializer)
         r = await job.result_info()
         r.job_id = job_id
         return r

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -1,10 +1,10 @@
 import asyncio
-import logging
 import functools
+import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from operator import attrgetter
-from typing import Any, List, Optional, Union, Callable
+from typing import Any, Callable, List, Optional, Union
 from uuid import uuid4
 
 import aioredis
@@ -164,9 +164,7 @@ async def create_pool(
             password=settings.password,
             timeout=settings.conn_timeout,
             encoding='utf8',
-            commands_factory=functools.partial(
-                ArqRedis, _serialize=_serialize, _deserialize=_deserialize,
-            ),
+            commands_factory=functools.partial(ArqRedis, _serialize=_serialize, _deserialize=_deserialize),
         )
     except (ConnectionError, OSError, aioredis.RedisError, asyncio.TimeoutError) as e:
         if _retry < settings.conn_retries:

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -46,8 +46,8 @@ class ArqRedis(Redis):
     Thin subclass of ``aioredis.Redis`` which adds :func:`arq.connections.enqueue_job`.
 
     :param redis_settings: an instance of ``arq.connections.RedisSettings``.
-    :param _job_serializer: a function that serializes Python objects to bytes, defaults to pickle.dumps
-    :param _job_deserializer: a function that deserializes bytes into Python objects, defaults to pickle.loads
+    :param job_serializer: a function that serializes Python objects to bytes, defaults to pickle.dumps
+    :param job_deserializer: a function that deserializes bytes into Python objects, defaults to pickle.loads
     :param kwargs: keyword arguments directly passed to ``aioredis.Redis``.
     """
 

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -145,7 +145,7 @@ def serialize_job(
     try:
         return _serialize(data)
     except Exception as e:
-        raise SerializationError(f'unable to pickle job "{function_name}"') from e
+        raise SerializationError(f'unable to serialize job "{function_name}"') from e
 
 
 def serialize_result(
@@ -178,7 +178,7 @@ def serialize_result(
     try:
         return _serialize(data)
     except Exception:
-        logger.warning('error pickling result of %s', ref, exc_info=True)
+        logger.warning('error serializing result of %s', ref, exc_info=True)
 
     data.update(r=SerializationError('unable to serialize result'), s=False)
     try:

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -94,7 +94,7 @@ class Job:
         if not info:
             v = await self._redis.get(job_key_prefix + self.job_id, encoding=None)
             if v:
-                info = unpickle_job(v, _deserialize=self._deserialize)
+                info = deserialize_job(v, _deserialize=self._deserialize)
         if info:
             info.score = await self._redis.zscore(self._queue_name, self.job_id)
         return info
@@ -106,7 +106,7 @@ class Job:
         """
         v = await self._redis.get(result_key_prefix + self.job_id, encoding=None)
         if v:
-            return unpickle_result(v, _deserialize=self._deserialize)
+            return deserialize_result(v, _deserialize=self._deserialize)
 
     async def status(self) -> JobStatus:
         """
@@ -130,11 +130,7 @@ class SerializationError(RuntimeError):
     pass
 
 
-class PickleError(SerializationError):
-    pass
-
-
-def pickle_job(
+def serialize_job(
     function_name: str,
     args: tuple,
     kwargs: dict,
@@ -152,7 +148,7 @@ def pickle_job(
         raise SerializationError(f'unable to pickle job "{function_name}"') from e
 
 
-def pickle_result(
+def serialize_result(
     function: str,
     args: tuple,
     kwargs: dict,
@@ -191,7 +187,7 @@ def pickle_result(
         logger.critical('error serializing result of %s even after replacing result', ref, exc_info=True)
 
 
-def unpickle_job(r: bytes, _deserialize: Optional[Callable[[bytes], Any]] = None) -> JobDef:
+def deserialize_job(r: bytes, _deserialize: Optional[Callable[[bytes], Any]] = None) -> JobDef:
     if _deserialize is None:
         _deserialize = pickle.loads
     try:
@@ -208,7 +204,7 @@ def unpickle_job(r: bytes, _deserialize: Optional[Callable[[bytes], Any]] = None
         raise SerializationError(f'unable to deserialize job: {r!r}') from e
 
 
-def unpickle_job_raw(r: bytes, _deserialize: Optional[Callable[[bytes], Any]] = None) -> tuple:
+def deserialize_job_raw(r: bytes, _deserialize: Optional[Callable[[bytes], Any]] = None) -> tuple:
     if _deserialize is None:
         _deserialize = pickle.loads
     try:
@@ -218,7 +214,7 @@ def unpickle_job_raw(r: bytes, _deserialize: Optional[Callable[[bytes], Any]] = 
         raise SerializationError(f'unable to deserialize job: {r!r}') from e
 
 
-def unpickle_result(r: bytes, _deserialize: Optional[Callable[[bytes], Any]] = None) -> JobResult:
+def deserialize_result(r: bytes, _deserialize: Optional[Callable[[bytes], Any]] = None) -> JobResult:
     if _deserialize is None:
         _deserialize = pickle.loads
     try:

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -59,11 +59,7 @@ class Job:
     __slots__ = 'job_id', '_redis', '_queue_name', '_deserializer'
 
     def __init__(
-        self,
-        job_id: str,
-        redis,
-        _queue_name: str = default_queue_name,
-        _deserializer: Optional[Deserializer] = None,
+        self, job_id: str, redis, _queue_name: str = default_queue_name, _deserializer: Optional[Deserializer] = None
     ):
         self.job_id = job_id
         self._redis = redis

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -124,6 +124,10 @@ class SerializationError(RuntimeError):
     pass
 
 
+class PickleError(SerializationError):
+    pass
+
+
 def pickle_job(
     function_name: str,
     args: tuple,

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -4,7 +4,7 @@ import pickle
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Optional, Callable
+from typing import Any, Callable, Optional
 
 from .constants import default_queue_name, in_progress_key_prefix, job_key_prefix, result_key_prefix
 from .utils import ms_to_datetime, poll, timestamp_ms
@@ -55,7 +55,13 @@ class Job:
 
     __slots__ = 'job_id', '_redis', '_queue_name', '_deserialize'
 
-    def __init__(self, job_id: str, redis, _queue_name: str = default_queue_name, _deserialize: Optional[Callable[[bytes], Any]] = None):
+    def __init__(
+        self,
+        job_id: str,
+        redis,
+        _queue_name: str = default_queue_name,
+        _deserialize: Optional[Callable[[bytes], Any]] = None,
+    ):
         self.job_id = job_id
         self._redis = redis
         self._queue_name = _queue_name
@@ -191,7 +197,12 @@ def unpickle_job(r: bytes, _deserialize: Optional[Callable[[bytes], Any]] = None
     try:
         d = _deserialize(r)
         return JobDef(
-            function=d['f'], args=d['a'], kwargs=d['k'], job_try=d['t'], enqueue_time=ms_to_datetime(d['et']), score=None
+            function=d['f'],
+            args=d['a'],
+            kwargs=d['k'],
+            job_try=d['t'],
+            enqueue_time=ms_to_datetime(d['et']),
+            score=None,
         )
     except Exception as e:
         raise SerializationError(f'unable to deserialize job: {r!r}') from e

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -336,12 +336,12 @@ class Worker:
                 start_ms,
                 timestamp_ms(),
                 f'{job_id}:<unknown function>',
-                _serialize=self.job_serializer,
+                serializer=self.job_serializer,
             )
             return await asyncio.shield(self.abort_job(job_id, result_data))
 
         function_name, args, kwargs, enqueue_job_try, enqueue_time_ms = deserialize_job_raw(
-            v, _deserialize=self.job_deserializer
+            v, deserializer=self.job_deserializer
         )
 
         try:
@@ -360,7 +360,7 @@ class Worker:
                 start_ms,
                 timestamp_ms(),
                 f'{job_id}:{function_name}',
-                _serialize=self.job_serializer,
+                serializer=self.job_serializer,
             )
             return await asyncio.shield(self.abort_job(job_id, result_data))
 
@@ -390,7 +390,7 @@ class Worker:
                 start_ms,
                 timestamp_ms(),
                 ref,
-                _serialize=self.job_serializer,
+                serializer=self.job_serializer,
             )
             return await asyncio.shield(self.abort_job(job_id, result_data))
 
@@ -465,7 +465,7 @@ class Worker:
                 start_ms,
                 finished_ms,
                 ref,
-                _serialize=self.job_serializer,
+                serializer=self.job_serializer,
             )
 
         await asyncio.shield(self.finish_job(job_id, finish, result_data, result_timeout_s, incr_score))

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -14,7 +14,7 @@ from aioredis import MultiExecError
 from pydantic.utils import import_string
 
 from arq.cron import CronJob
-from arq.jobs import pickle_result, unpickle_job_raw
+from arq.jobs import serialize_result, deserialize_job_raw
 
 from .connections import ArqRedis, RedisSettings, create_pool, log_redis_info
 from .constants import (
@@ -141,8 +141,8 @@ class Worker:
     :param max_tries: default maximum number of times to retry a job
     :param health_check_interval: how often to set the health check key
     :param health_check_key: redis key under which health check is set
-    :param serialize: a function that serializes Python objects to bytes, defaults to pickle.dumps
-    :param deserialize: a function that deserializes bytes into Python objects, defaults to pickle.loads
+    :param job_serializer: a function that serializes Python objects to bytes, defaults to pickle.dumps
+    :param job_deserializer: a function that deserializes bytes into Python objects, defaults to pickle.loads
     """
 
     def __init__(
@@ -166,8 +166,8 @@ class Worker:
         ctx: Optional[Dict] = None,
         retry_jobs: bool = True,
         max_burst_jobs: int = -1,
-        serialize: Optional[Callable[[Any], bytes]] = None,
-        deserialize: Optional[Callable[[bytes], Any]] = None,
+        job_serializer: Optional[Callable[[Any], bytes]] = None,
+        job_deserializer: Optional[Callable[[bytes], Any]] = None,
     ):
         self.functions: Dict[str, Union[Function, CronJob]] = {f.name: f for f in map(func, functions)}
         self.queue_name = queue_name
@@ -212,8 +212,8 @@ class Worker:
         # whether or not to retry jobs on Retry and CancelledError
         self.retry_jobs = retry_jobs
         self.max_burst_jobs = max_burst_jobs
-        self.serialize = serialize
-        self.deserialize = deserialize
+        self.job_serializer = job_serializer
+        self.job_deserializer = job_deserializer
 
     def run(self) -> None:
         """
@@ -325,7 +325,7 @@ class Worker:
         if not v:
             logger.warning('job %s expired', job_id)
             self.jobs_failed += 1
-            result_data = pickle_result(
+            result_data = serialize_result(
                 '<unknown>',
                 (),
                 {},
@@ -336,12 +336,12 @@ class Worker:
                 start_ms,
                 timestamp_ms(),
                 f'{job_id}:<unknown function>',
-                _serialize=self.serialize,
+                _serialize=self.job_serializer,
             )
             return await asyncio.shield(self.abort_job(job_id, result_data))
 
-        function_name, args, kwargs, enqueue_job_try, enqueue_time_ms = unpickle_job_raw(
-            v, _deserialize=self.deserialize
+        function_name, args, kwargs, enqueue_job_try, enqueue_time_ms = deserialize_job_raw(
+            v, _deserialize=self.job_deserializer
         )
 
         try:
@@ -349,7 +349,7 @@ class Worker:
         except KeyError:
             logger.warning('job %s, function %r not found', job_id, function_name)
             self.jobs_failed += 1
-            result_data = pickle_result(
+            result_data = serialize_result(
                 function_name,
                 args,
                 kwargs,
@@ -360,7 +360,7 @@ class Worker:
                 start_ms,
                 timestamp_ms(),
                 f'{job_id}:{function_name}',
-                _serialize=self.serialize,
+                _serialize=self.job_serializer,
             )
             return await asyncio.shield(self.abort_job(job_id, result_data))
 
@@ -379,7 +379,7 @@ class Worker:
             t = (timestamp_ms() - enqueue_time_ms) / 1000
             logger.warning('%6.2fs ! %s max retries %d exceeded', t, ref, max_tries)
             self.jobs_failed += 1
-            result_data = pickle_result(
+            result_data = serialize_result(
                 function_name,
                 args,
                 kwargs,
@@ -390,7 +390,7 @@ class Worker:
                 start_ms,
                 timestamp_ms(),
                 ref,
-                _serialize=self.serialize,
+                _serialize=self.job_serializer,
             )
             return await asyncio.shield(self.abort_job(job_id, result_data))
 
@@ -454,7 +454,7 @@ class Worker:
         result_timeout_s = self.keep_result_s if function.keep_result_s is None else function.keep_result_s
         result_data = None
         if result is not no_result and result_timeout_s > 0:
-            result_data = pickle_result(
+            result_data = serialize_result(
                 function_name,
                 args,
                 kwargs,
@@ -465,7 +465,7 @@ class Worker:
                 start_ms,
                 finished_ms,
                 ref,
-                _serialize=self.serialize,
+                _serialize=self.job_serializer,
             )
 
         await asyncio.shield(self.finish_job(job_id, finish, result_data, result_timeout_s, incr_score))

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from functools import partial
 from signal import Signals
 from time import time
-from typing import Awaitable, Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Union
 
 import async_timeout
 from aioredis import MultiExecError
@@ -340,7 +340,9 @@ class Worker:
             )
             return await asyncio.shield(self.abort_job(job_id, result_data))
 
-        function_name, args, kwargs, enqueue_job_try, enqueue_time_ms = unpickle_job_raw(v, _deserialize=self.deserialize)
+        function_name, args, kwargs, enqueue_job_try, enqueue_time_ms = unpickle_job_raw(
+            v, _deserialize=self.deserialize
+        )
 
         try:
             function: Union[Function, CronJob] = self.functions[function_name]

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -14,7 +14,7 @@ from aioredis import MultiExecError
 from pydantic.utils import import_string
 
 from arq.cron import CronJob
-from arq.jobs import Serializer, Deserializer, serialize_result, deserialize_job_raw
+from arq.jobs import Deserializer, Serializer, deserialize_job_raw, serialize_result
 
 from .connections import ArqRedis, RedisSettings, create_pool, log_redis_info
 from .constants import (

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -7,14 +7,14 @@ from datetime import datetime
 from functools import partial
 from signal import Signals
 from time import time
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Union
+from typing import Awaitable, Callable, Dict, List, Optional, Sequence, Union
 
 import async_timeout
 from aioredis import MultiExecError
 from pydantic.utils import import_string
 
 from arq.cron import CronJob
-from arq.jobs import serialize_result, deserialize_job_raw
+from arq.jobs import Serializer, Deserializer, serialize_result, deserialize_job_raw
 
 from .connections import ArqRedis, RedisSettings, create_pool, log_redis_info
 from .constants import (
@@ -166,8 +166,8 @@ class Worker:
         ctx: Optional[Dict] = None,
         retry_jobs: bool = True,
         max_burst_jobs: int = -1,
-        job_serializer: Optional[Callable[[Any], bytes]] = None,
-        job_deserializer: Optional[Callable[[bytes], Any]] = None,
+        job_serializer: Optional[Serializer] = None,
+        job_deserializer: Optional[Deserializer] = None,
     ):
         self.functions: Dict[str, Union[Function, CronJob]] = {f.name: f for f in map(func, functions)}
         self.queue_name = queue_name

--- a/docs/examples/custom_serialization_msgpack.py
+++ b/docs/examples/custom_serialization_msgpack.py
@@ -13,8 +13,8 @@ async def the_task(ctx):
 async def main():
     redis = await create_pool(
         RedisSettings(),
-        _job_serializer=msgpack.packb,
-        _job_deserializer=lambda b: msgpack.unpackb(b, raw=False),
+        job_serializer=msgpack.packb,
+        job_deserializer=lambda b: msgpack.unpackb(b, raw=False),
     )
     await redis.enqueue_job('the_task', _defer_by=10)
 

--- a/docs/examples/custom_serialization_msgpack.py
+++ b/docs/examples/custom_serialization_msgpack.py
@@ -16,7 +16,7 @@ async def main():
         job_serializer=msgpack.packb,
         job_deserializer=lambda b: msgpack.unpackb(b, raw=False),
     )
-    await redis.enqueue_job('the_task', _defer_by=10)
+    await redis.enqueue_job('the_task')
 
 
 class WorkerSettings:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -170,7 +170,7 @@ optionally with a duration to defer rerunning the jobs by:
 Health checks
 .............
 
-*arq* will automatically record some info about it's current state in redis every ``health_check_interval`` seconds.
+*arq* will automatically record some info about its current state in redis every ``health_check_interval`` seconds.
 That key/value will expire after ``health_check_interval + 1`` seconds so you can be sure if the variable exists *arq*
 is alive and kicking (technically you can be sure it was alive and kicking ``health_check_interval`` seconds ago).
 
@@ -205,6 +205,28 @@ As per the example sets can be used to run at multiple of the given unit.
 Note that ``second`` defaults to ``0`` so you don't in inadvertently run jobs every second and ``microsecond``
 defaults to ``123456`` so you don't inadvertently run jobs every microsecond and so *arq* avoids enqueuing jobs
 at the top of a second when the world is generally slightly busier.
+
+Custom job serializers
+......................
+
+By default, *arq* will use the built-in ``pickle`` module to serialize and deserialize jobs. If you wish to
+use an alternative serialization methods, you can do so by specifying them when creating the connection pool
+and the worker settings. A serializer function takes a Python object and returns a binary representation
+encoded in a ``bytes`` object. A deserializer function, on the other hand, creates Python objects out of
+a ``bytes`` sequence.
+
+.. warning::
+   It is essential that the serialization functions used by :func:`arq.connections.create_pool` and
+   :class:`arq.worker.Worker` are the same, otherwise jobs created by the former cannot be executed by the
+   latter. This also applies when you update your serialization functions: you need to ensure that your new
+   functions are backward compatible with the old jobs, or that there are no jobs with the older serialization
+   scheme in the queue.
+
+Here is an example with `MsgPack <http://msgpack.org>`_, an efficient binary serialization format that
+may enable significant memory improvements over pickle:
+
+.. literalinclude:: examples/custom_serialization_msgpack.py
+
 
 Reference
 ---------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import functools
 
-import pytest
 import msgpack
+import pytest
 from aioredis import create_redis_pool
 
 from arq.connections import ArqRedis
@@ -19,10 +19,14 @@ async def arq_redis(loop):
 
 @pytest.yield_fixture
 async def arq_redis_msgpack(loop):
-    redis_ = await create_redis_pool(('localhost', 6379), encoding='utf8',
-            loop=loop, commands_factory=functools.partial(ArqRedis,
-                _job_serializer=msgpack.packb,
-                _job_deserializer=functools.partial(msgpack.unpackb, raw=False)))
+    redis_ = await create_redis_pool(
+        ('localhost', 6379),
+        encoding='utf8',
+        loop=loop,
+        commands_factory=functools.partial(
+            ArqRedis, _job_serializer=msgpack.packb, _job_deserializer=functools.partial(msgpack.unpackb, raw=False)
+        ),
+    )
     await redis_.flushall()
     yield redis_
     redis_.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ async def arq_redis_msgpack(loop):
         encoding='utf8',
         loop=loop,
         commands_factory=functools.partial(
-            ArqRedis, _job_serializer=msgpack.packb, _job_deserializer=functools.partial(msgpack.unpackb, raw=False)
+            ArqRedis, job_serializer=msgpack.packb, job_deserializer=functools.partial(msgpack.unpackb, raw=False)
         ),
     )
     await redis_.flushall()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,3 +12,4 @@ pytest-mock==1.10.4
 pytest-sugar==0.9.2
 pytest-timeout==1.3.3
 pytest-toolbox==0.4
+msgpack==0.6.1

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -88,10 +88,10 @@ async def test_custom_serializer():
         def __getstate__(self):
             raise TypeError("this doesn't pickle")
 
-    def custom_serialize(x):
+    def custom_serializer(x):
         return b'0123456789'
 
-    r1 = serialize_result('foobar', (1,), {}, 1, 123, True, Foobar(), 123, 123, 'testing', _serialize=custom_serialize)
+    r1 = serialize_result('foobar', (1,), {}, 1, 123, True, Foobar(), 123, 123, 'testing', serializer=custom_serializer)
     assert r1 == b'0123456789'
-    r2 = serialize_result('foobar', (Foobar(),), {}, 1, 123, True, Foobar(), 123, 123, 'testing', _serialize=custom_serialize)
+    r2 = serialize_result('foobar', (Foobar(),), {}, 1, 123, True, Foobar(), 123, 123, 'testing', serializer=custom_serializer)
     assert r2 == b'0123456789'

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -6,7 +6,7 @@ from pytest_toolbox.comparison import CloseToNow
 from arq import Worker, func
 from arq.connections import ArqRedis
 from arq.constants import in_progress_key_prefix
-from arq.jobs import Job, JobResult, JobStatus, pickle_result
+from arq.jobs import Job, JobResult, JobStatus, serialize_result
 
 
 async def test_job_in_progress(arq_redis: ArqRedis):
@@ -77,7 +77,7 @@ async def test_cant_unpickel_at_all():
         def __getstate__(self):
             raise TypeError("this doesn't pickle")
 
-    r1 = pickle_result('foobar', (1,), {}, 1, 123, True, Foobar(), 123, 123, 'testing')
+    r1 = serialize_result('foobar', (1,), {}, 1, 123, True, Foobar(), 123, 123, 'testing')
     assert isinstance(r1, bytes)
-    r2 = pickle_result('foobar', (Foobar(),), {}, 1, 123, True, Foobar(), 123, 123, 'testing')
+    r2 = serialize_result('foobar', (Foobar(),), {}, 1, 123, True, Foobar(), 123, 123, 'testing')
     assert r2 is None

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -93,5 +93,7 @@ async def test_custom_serializer():
 
     r1 = serialize_result('foobar', (1,), {}, 1, 123, True, Foobar(), 123, 123, 'testing', serializer=custom_serializer)
     assert r1 == b'0123456789'
-    r2 = serialize_result('foobar', (Foobar(),), {}, 1, 123, True, Foobar(), 123, 123, 'testing', serializer=custom_serializer)
+    r2 = serialize_result(
+        'foobar', (Foobar(),), {}, 1, 123, True, Foobar(), 123, 123, 'testing', serializer=custom_serializer
+    )
     assert r2 == b'0123456789'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,7 @@ from pytest_toolbox.comparison import CloseToNow
 
 from arq.connections import ArqRedis
 from arq.constants import default_queue_name
-from arq.jobs import Job, PickleError
+from arq.jobs import Job, SerializationError
 from arq.utils import timestamp_ms
 from arq.worker import Retry, Worker, func
 
@@ -145,7 +145,7 @@ async def test_cant_pickle_arg(arq_redis: ArqRedis, worker):
         def __getstate__(self):
             raise TypeError("this doesn't pickle")
 
-    with pytest.raises(PickleError):
+    with pytest.raises(SerializationError):
         await arq_redis.enqueue_job('foobar', Foobar())
 
 
@@ -160,5 +160,5 @@ async def test_cant_pickle_result(arq_redis: ArqRedis, worker):
     j1 = await arq_redis.enqueue_job('foobar')
     w: Worker = worker(functions=[func(foobar, name='foobar')])
     await w.main()
-    with pytest.raises(PickleError):
+    with pytest.raises(SerializationError):
         await j1.result(pole_delay=0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,7 +32,7 @@ async def test_redis_success_log(caplog):
     pool.close()
     await pool.wait_closed()
 
-    pool = await create_pool(settings, _retry=1)
+    pool = await create_pool(settings, retry=1)
     assert 'redis connection successful' in [r.message for r in caplog.records]
     pool.close()
     await pool.wait_closed()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -469,7 +469,7 @@ async def test_incompatible_serializers_1(arq_redis_msgpack: ArqRedis, worker):
     worker: Worker = worker(functions=[foobar])
     with pytest.raises(SerializationError) as exc_info:
         await worker.main()
-        assert exc_info.value.startswith('unable to deserialize job: ')
+    assert exc_info.value.startswith('unable to deserialize job: ')
 
 
 async def test_incompatible_serializers_2(arq_redis: ArqRedis, worker):
@@ -479,4 +479,4 @@ async def test_incompatible_serializers_2(arq_redis: ArqRedis, worker):
     )
     with pytest.raises(SerializationError) as exc_info:
         await worker.main()
-        assert exc_info.value.startswith('unable to deserialize job: ')
+    assert exc_info.value.startswith('unable to deserialize job: ')

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5,8 +5,8 @@ import re
 import signal
 from unittest.mock import MagicMock
 
-import pytest
 import msgpack
+import pytest
 from aioredis import create_redis_pool
 
 from arq.connections import ArqRedis
@@ -455,7 +455,9 @@ async def test_repeat_job_result(arq_redis: ArqRedis, worker):
 
 async def test_custom_serializers(arq_redis_msgpack: ArqRedis, worker):
     j = await arq_redis_msgpack.enqueue_job('foobar', _job_id='job_id')
-    worker: Worker = worker(functions=[foobar], job_serializer=msgpack.packb, job_deserializer=functools.partial(msgpack.unpackb, raw=False))
+    worker: Worker = worker(
+        functions=[foobar], job_serializer=msgpack.packb, job_deserializer=functools.partial(msgpack.unpackb, raw=False)
+    )
     await worker.main()
     assert await j.result() == 42
     r = await j.info()
@@ -472,7 +474,9 @@ async def test_incompatible_serializers_1(arq_redis_msgpack: ArqRedis, worker):
 
 async def test_incompatible_serializers_2(arq_redis: ArqRedis, worker):
     await arq_redis.enqueue_job('foobar', _job_id='job_id')
-    worker: Worker = worker(functions=[foobar], job_serializer=msgpack.packb, job_deserializer=functools.partial(msgpack.unpackb, raw=False))
+    worker: Worker = worker(
+        functions=[foobar], job_serializer=msgpack.packb, job_deserializer=functools.partial(msgpack.unpackb, raw=False)
+    )
     with pytest.raises(SerializationError) as exc_info:
         await worker.main()
         assert exc_info.value.startswith('unable to deserialize job: ')

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -469,7 +469,7 @@ async def test_incompatible_serializers_1(arq_redis_msgpack: ArqRedis, worker):
     worker: Worker = worker(functions=[foobar])
     with pytest.raises(SerializationError) as exc_info:
         await worker.main()
-    assert exc_info.value.startswith('unable to deserialize job: ')
+    assert exc_info.value.args[0].startswith('unable to deserialize job: ')
 
 
 async def test_incompatible_serializers_2(arq_redis: ArqRedis, worker):
@@ -479,4 +479,4 @@ async def test_incompatible_serializers_2(arq_redis: ArqRedis, worker):
     )
     with pytest.raises(SerializationError) as exc_info:
         await worker.main()
-    assert exc_info.value.startswith('unable to deserialize job: ')
+    assert exc_info.value.args[0].startswith('unable to deserialize job: ')

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -467,6 +467,7 @@ async def test_incompatible_serializers_1(arq_redis_msgpack: ArqRedis, worker):
     worker: Worker = worker(functions=[foobar])
     with pytest.raises(SerializationError) as exc_info:
         await worker.main()
+        assert exc_info.value.startswith('unable to deserialize job: ')
 
 
 async def test_incompatible_serializers_2(arq_redis: ArqRedis, worker):
@@ -474,3 +475,4 @@ async def test_incompatible_serializers_2(arq_redis: ArqRedis, worker):
     worker: Worker = worker(functions=[foobar], job_serializer=msgpack.packb, job_deserializer=functools.partial(msgpack.unpackb, raw=False))
     with pytest.raises(SerializationError) as exc_info:
         await worker.main()
+        assert exc_info.value.startswith('unable to deserialize job: ')


### PR DESCRIPTION
## Changes

I would like to propose this change, which allows the user to specify custom serializers in alternative to pickle, which is left as the default.

The public API is changed only very slightly: there are new `_serialize` and `_deserialize` arguments to `create_pool` and `Worker`. The rest of the changes essentially reduces to passing these to the pickle functions.

For backward compatibility, I have left the `pickle_jobs`, etc. functions in `arq.jobs` with the same name, even though the name is slightly inappropriate now.

## Rationale

The main reason I am proposing this change is to allow better memory usage. The default serialization method, pickle, is quite space inefficient. Since the job data is essentially JSON, we can attain much better memory usage by switching to serialization methods that are more appropriate.

In my case, by using [MsgPack](https://msgpack.org/) instead of Pickle, I am seeing an improvement of 47%-49% in memory usage which is quite significant. At tens to hundreds of thousands of tasks this means hundreds of MBs if not GBs in savings.

## Usage

The usage is quite simple. Existing code works as usual, but one can use a different serialization method as follows:

```python
import msgpack
from arq.connections import create_pool, RedisSettings

pool = await create_pool(RedisSettings(), _serialize=msgpack.packb, _deserialize=msgpack.unpackb)

WorkerSettings:
    serialize = msgpack.packb
    deserialize = msgpack.unpackb
```

## Tests and documentation
The tests pass, except two tests that also fail on master. If this change is approved, I can write a paragraph in the documentation on custom serialization functions.