### PR TITLE
Fix abort_job invalid expire time in setex

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 v0.18.1 (unreleased)
 ....................
 * add support for Redis Sentinel fix #132
+* fix ``Worker.abort_job`` invalid expire time error, by @dmvass
 
 v0.18 (2019-08-30)
 ..................

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -510,7 +510,7 @@ class Worker:
             tr.delete(retry_key_prefix + job_id, in_progress_key_prefix + job_id, job_key_prefix + job_id)
             tr.zrem(self.queue_name, job_id)
             # result_data would only be None if serializing the result fails
-            if result_data is not None:  # pragma: no branch
+            if result_data is not None and self.keep_result_s > 0:  # pragma: no branch
                 tr.setex(result_key_prefix + job_id, self.keep_result_s, result_data)
             await tr.execute()
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 
 import msgpack
 import pytest
-from aioredis import MultiExecError, create_redis_pool
+from aioredis import create_redis_pool
 
 from arq.connections import ArqRedis
 from arq.constants import default_queue_name, health_check_key_suffix, job_key_prefix

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 
 import msgpack
 import pytest
-from aioredis import create_redis_pool, MultiExecError
+from aioredis import MultiExecError, create_redis_pool
 
 from arq.connections import ArqRedis
 from arq.constants import default_queue_name, health_check_key_suffix, job_key_prefix

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -195,10 +195,7 @@ async def test_retry_lots_without_keep_result(arq_redis: ArqRedis, worker):
 
     await arq_redis.enqueue_job('retry', _job_id='testing')
     worker: Worker = worker(functions=[func(retry, name='retry')], keep_result=0)
-    try:
-        await worker.main()
-    except MultiExecError:  # raises on invalid expire time in setex
-        raise pytest.fail(f'DID RAISE {MultiExecError}')
+    await worker.main()  # Should not raise MultiExecError
 
 
 async def test_retry_lots_check(arq_redis: ArqRedis, worker, caplog):


### PR DESCRIPTION
**What**:
Fix abort_job `ERR invalid expire time in setex` on keep_result 0.


```
Traceback (most recent call last):
  File ".../.venv/bin/arq", line 10, in <module>
    sys.exit(cli())
  File ".../.venv/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File ".../.venv/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File ".../.venv/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/.../.venv/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File ".../.venv/lib/python3.7/site-packages/arq/cli.py", line 45, in cli
    run_worker(worker_settings, **kwargs)
  File ".../.venv/lib/python3.7/site-packages/arq/worker.py", line 610, in run_worker
    worker.run()
  File ".../.venv/lib/python3.7/site-packages/arq/worker.py", line 231, in run
    self.loop.run_until_complete(self.main_task)
  File "/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/base_events.py", line 579, in run_until_complete
    return future.result()
  File ".../.venv/lib/python3.7/site-packages/arq/worker.py", line 274, in main
    await self._poll_iteration()
  File ".../.venv/lib/python3.7/site-packages/arq/worker.py", line 304, in _poll_iteration
    t.result()
  File ".../.venv/lib/python3.7/site-packages/arq/worker.py", line 411, in run_job
    return await asyncio.shield(self.abort_job(job_id, result_data))
  File ".../.venv/lib/python3.7/site-packages/arq/worker.py", line 515, in abort_job
    await tr.execute()
  File ".../.venv/lib/python3.7/site-packages/aioredis/commands/transaction.py", line 180, in execute
    return_exceptions=return_exceptions)
  File ".../.venv/lib/python3.7/site-packages/aioredis/commands/transaction.py", line 298, in _do_execute
    self._resolve_waiters(results, return_exceptions)
  File ".../.venv/lib/python3.7/site-packages/aioredis/commands/transaction.py", line 310, in _resolve_waiters
    raise MultiExecError(errors)
aioredis.errors.MultiExecError: ('MultiExecError errors:', [ReplyError('ERR invalid expire time in setex')])
```