### PR TITLE
Close underlying sentinel pool when worker is closed

### DIFF
--- a/arq/connections.py
+++ b/arq/connections.py
@@ -141,7 +141,6 @@ class ArqRedis(Redis):
         await super().wait_closed()
         if hasattr(self, '_sentinel'):
             await self._sentinel.wait_closed()
-        return
 
     async def _get_job_result(self, key) -> JobResult:
         job_id = key[len(result_key_prefix) :]

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -131,6 +131,18 @@ class ArqRedis(Redis):
                 return
         return Job(job_id, redis=self, _deserializer=self.job_deserializer)
 
+    def close(self):
+        super().close()
+        if hasattr(self, '_sentinel'):
+            self._sentinel.close()
+        return
+
+    async def wait_closed(self):
+        await super().wait_closed()
+        if hasattr(self, '_sentinel'):
+            await self._sentinel.wait_closed()
+        return
+
     async def _get_job_result(self, key) -> JobResult:
         job_id = key[len(result_key_prefix) :]
         job = Job(job_id, self, _deserializer=self.job_deserializer)


### PR DESCRIPTION
Hey @samuelcolvin, 

Thanks for merging the PR adding support for Redis Sentinel.  

**ISSUE:** 

I just noticed that calling `close()` on the ManagedPool that is created using `pool.master_for(TK)` in https://github.com/samuelcolvin/arq/blob/master/arq/connections.py#L187 does not actually close the underlying sentinel pool that is created at https://github.com/samuelcolvin/arq/blob/master/arq/connections.py#L186.

This leads to asyncio errors when exiting the program.  

**FIX:** 

I was thinking this could be fixed by checking for the existence of an `_sentinel` property on the Redis (ArqRedis) object to check if the underlying connection is a sentinel connection and additionally call `client._sentinel.close()` and await on `client._sentinel.wait_closed()` to ensure that the connection is fully closed.