### PR TITLE
Fix cron scheduling on a specific queue

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.18.2 (unreleased)
+....................
+* Fix cron scheduling on a specific queue, by @dmvass and @Tinche
+
 v0.18.1 (2019-10-28)
 ....................
 * add support for Redis Sentinel fix #132

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -531,7 +531,7 @@ class Worker:
 
             if n >= cron_job.next_run:
                 job_id = f'{cron_job.name}:{to_unix_ms(cron_job.next_run)}' if cron_job.unique else None
-                job_futures.add(self.pool.enqueue_job(cron_job.name, _job_id=job_id))
+                job_futures.add(self.pool.enqueue_job(cron_job.name, _job_id=job_id, _queue_name=self.queue_name))
                 cron_job.set_next(n)
 
         job_futures and await asyncio.gather(*job_futures)

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -101,6 +101,20 @@ async def test_job_successful(worker, caplog):
     assert '  0.XXs → cron:foobar()\n  0.XXs ← cron:foobar ● 42' in log
 
 
+async def test_job_successful_on_specific_queue(worker, caplog):
+    caplog.set_level(logging.INFO)
+    worker: Worker = worker(
+        queue_name='arq:test-cron-queue',
+        cron_jobs=[cron(foobar, hour=1, run_at_startup=True)])
+    await worker.main()
+    assert worker.jobs_complete == 1
+    assert worker.jobs_failed == 0
+    assert worker.jobs_retried == 0
+
+    log = re.sub(r'(\d+).\d\ds', r'\1.XXs', '\n'.join(r.message for r in caplog.records))
+    assert '  0.XXs → cron:foobar()\n  0.XXs ← cron:foobar ● 42' in log
+
+
 async def test_not_run(worker, caplog):
     caplog.set_level(logging.INFO)
     worker: Worker = worker(cron_jobs=[cron(foobar, hour=1, run_at_startup=False)])

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -103,9 +103,7 @@ async def test_job_successful(worker, caplog):
 
 async def test_job_successful_on_specific_queue(worker, caplog):
     caplog.set_level(logging.INFO)
-    worker: Worker = worker(
-        queue_name='arq:test-cron-queue',
-        cron_jobs=[cron(foobar, hour=1, run_at_startup=True)])
+    worker: Worker = worker(queue_name='arq:test-cron-queue', cron_jobs=[cron(foobar, hour=1, run_at_startup=True)])
     await worker.main()
     assert worker.jobs_complete == 1
     assert worker.jobs_failed == 0


### PR DESCRIPTION
**Why**:
Cron is not working correct when worker was started with a specific `queue_name`.

**What:**
Use the worker `queue_name` when enqueue cron jobs.

Sorry that I so late noticed that a similar fix is already in progress, added original issuer as co-author for my PR. Anyway feel free to close this one.

Co-authored-by: Tin Tvrtković <tinchester@gmail.com>