### PR TITLE
Include queue_name when returning job object after performing enqueue_job

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.18.2 (unreleased)
+....................
+* Include ``queue_name`` when for job object in response to ``enqueue_job``, #160
+
 v0.18.2 (2019-11-01)
 ....................
 * Fix cron scheduling on a specific queue, by @dmvass and @Tinche

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -129,7 +129,7 @@ class ArqRedis(Redis):
                 # https://github.com/samuelcolvin/arq/issues/131, avoid warnings in log
                 await asyncio.gather(*tr._results, return_exceptions=True)
                 return
-        return Job(job_id, redis=self, _deserializer=self.job_deserializer)
+        return Job(job_id, redis=self, _queue_name=_queue_name, _deserializer=self.job_deserializer)
 
     async def _get_job_result(self, key) -> JobResult:
         job_id = key[len(result_key_prefix) :]

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -6,7 +6,7 @@ from pytest_toolbox.comparison import CloseToNow
 
 from arq import Worker, func
 from arq.connections import ArqRedis
-from arq.constants import in_progress_key_prefix, job_key_prefix, result_key_prefix
+from arq.constants import in_progress_key_prefix, job_key_prefix, result_key_prefix, default_queue_name
 from arq.jobs import DeserializationError, Job, JobResult, JobStatus, deserialize_job_raw, serialize_result
 
 
@@ -30,14 +30,14 @@ async def test_result_timeout(arq_redis: ArqRedis):
         await j.result(0.1, pole_delay=0)
 
 
-async def test_enqueue_job(arq_redis: ArqRedis, worker):
+async def test_enqueue_job(arq_redis: ArqRedis, worker, queue_name=default_queue_name):
     async def foobar(ctx, *args, **kwargs):
         return 42
 
-    j = await arq_redis.enqueue_job('foobar', 1, 2, c=3)
+    j = await arq_redis.enqueue_job('foobar', 1, 2, c=3, _queue_name=queue_name)
     assert isinstance(j, Job)
     assert JobStatus.queued == await j.status()
-    worker: Worker = worker(functions=[func(foobar, name='foobar')])
+    worker: Worker = worker(functions=[func(foobar, name='foobar')], queue_name=queue_name)
     await worker.main()
     r = await j.result(pole_delay=0)
     assert r == 42
@@ -72,6 +72,8 @@ async def test_enqueue_job(arq_redis: ArqRedis, worker):
         )
     ]
 
+async def test_enqueue_job_alt_queue(arq_redis: ArqRedis, worker):
+    await test_enqueue_job(arq_redis, worker, queue_name='custom_queue')
 
 async def test_cant_unpickle_at_all():
     class Foobar:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -6,7 +6,7 @@ from pytest_toolbox.comparison import CloseToNow
 
 from arq import Worker, func
 from arq.connections import ArqRedis
-from arq.constants import in_progress_key_prefix, job_key_prefix, result_key_prefix, default_queue_name
+from arq.constants import default_queue_name, in_progress_key_prefix, job_key_prefix, result_key_prefix
 from arq.jobs import DeserializationError, Job, JobResult, JobStatus, deserialize_job_raw, serialize_result
 
 
@@ -72,8 +72,10 @@ async def test_enqueue_job(arq_redis: ArqRedis, worker, queue_name=default_queue
         )
     ]
 
+
 async def test_enqueue_job_alt_queue(arq_redis: ArqRedis, worker):
     await test_enqueue_job(arq_redis, worker, queue_name='custom_queue')
+
 
 async def test_cant_unpickle_at_all():
     class Foobar:


### PR DESCRIPTION
This will allow working with job objects when a non-default queue is specified.

```
j = arq.enqueue_job(TK, _queue_name='new queue')
status = await j.status()
```

Right now the object provided in response to `enqueue_job` uses the `default_queue_name`.

I will write up tests and update HISTORY tomorrow morning.

Hope you have a good weekend!