### PR TITLE
Fix workers concurrency

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.18.5 (2020-02-11)
+....................
+* Fix workers concurrency
+
 v0.18.4 (2019-12-19)
 ....................
 * Add ``py.typed`` file to tell mypy the package has type hints, #163

--- a/arq/version.py
+++ b/arq/version.py
@@ -2,4 +2,4 @@ from distutils.version import StrictVersion
 
 __all__ = ['VERSION']
 
-VERSION = StrictVersion('0.18.4')
+VERSION = StrictVersion('0.18.5')

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -295,6 +295,8 @@ class Worker:
             job_ids = await self.pool.zrangebyscore(
                 self.queue_name, offset=self._queue_read_offset, count=count, max=now
             )
+            if job_ids == [] and self._queue_read_offset > 0:
+                self._queue_read_offset = 0
         await self.run_jobs(job_ids)
 
         for t in self.tasks:

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -319,8 +319,10 @@ class Worker:
                 if ongoing_exists or not score:
                     # job already started elsewhere, or already finished and removed from queue
                     self.sem.release()
+                    self._queue_read_offset += 1
                     continue
 
+                self._queue_read_offset = 0
                 tr = conn.multi_exec()
                 tr.setex(in_progress_key, self.in_progress_timeout_s, b'1')
                 try:


### PR DESCRIPTION
When running several workers, the following situation can occur:

Let's say two workers are running and each one allow two jobs maximum at the same time.

- The first worker takes the two firsts jobs of the queue
- The second worker get the two firsts jobs, but sees that they are ran by another worker. It skips both of them and start again with the same jobs until they are completed by the first worker.
- The second worker will keep doing that until it is the first one to see a job.

To fix this problem, we just increment the `_queue_read_offset` variable, which will allow the worker to get jobs after the ones that are currently running elsewhere.