### PR TITLE
fix concurrency with multiple workers

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,9 +3,10 @@
 History
 -------
 
-v0.18.5 (unreleased)
+v0.19.0 (unreleased)
 ....................
-* Python 3.8 support
+* Python 3.8 support, #178
+* fix concurrency with multiple workers, #180
 
 v0.18.4 (2019-12-19)
 ....................

--- a/arq/version.py
+++ b/arq/version.py
@@ -1,3 +1,3 @@
 __all__ = ('VERSION',)
 
-VERSION = '0.18.5a1'
+VERSION = '0.19a1'


### PR DESCRIPTION
replace #170

The point here is that each worker needs to get more job ids from the queue than it's able to run in case some of those jobs are already running.

This problem will have been introduced by #142