### PR TITLE
Use builtin timestamp and fix timezone issues

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,10 @@
 History
 -------
 
+v0.19.1 (unreleased)
+....................
+* fix timestamp issue in _defer_until without timezone offset, #182
+
 v0.19.0 (2020-04-24)
 ....................
 * Python 3.8 support, #178

--- a/arq/utils.py
+++ b/arq/utils.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from time import time
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Optional, Sequence, overload
 
@@ -8,10 +8,6 @@ logger = logging.getLogger('arq.utils')
 
 if TYPE_CHECKING:
     from .typing import SecondsTimedelta
-
-
-epoch = datetime(1970, 1, 1)
-epoch_tz = epoch.replace(tzinfo=timezone.utc)
 
 
 def as_int(f: float) -> int:
@@ -23,16 +19,11 @@ def timestamp_ms() -> int:
 
 
 def to_unix_ms(dt: datetime) -> int:
-    """
-    convert a datetime to number of milliseconds since 1970 and calculate timezone offset
-    """
-    utcoffset = dt.utcoffset()
-    ep = epoch if utcoffset is None else epoch_tz
-    return as_int((dt - ep).total_seconds() * 1000)
+    return as_int(dt.timestamp() * 1000)
 
 
 def ms_to_datetime(unix_ms: int) -> datetime:
-    return epoch + timedelta(seconds=unix_ms / 1000)
+    return datetime.fromtimestamp(unix_ms / 1000)
 
 
 @overload

--- a/arq/utils.py
+++ b/arq/utils.py
@@ -19,6 +19,9 @@ def timestamp_ms() -> int:
 
 
 def to_unix_ms(dt: datetime) -> int:
+    """
+    convert a datetime to epoch with milliseconds as int
+    """
     return as_int(dt.timestamp() * 1000)
 
 


### PR DESCRIPTION
Fixes passing a `datetime` without time zone information to `_defer_until` being assumed to be at utc and this incorrectly deferring the task.

The issue can be replicated with this code. Just switch between lines 2-3 in the `main()`. If the computer's timezone is not utc this will be an issue.

```
import asyncio
from datetime import datetime, timedelta, timezone

from arq import create_pool
from arq.connections import RedisSettings


def utc_to_local(utc_dt):
    return utc_dt.replace(tzinfo=timezone.utc).astimezone(tz=None)


async def task(ctx, due_date):
    print("***************** New Task ***************")
    print(f"The task was enqueued at {utc_to_local(ctx['enqueue_time'])}")
    print(f"With due date {utc_to_local(due_date)}")
    print(f"and the time is {datetime.now()}")


async def main():
    redis = await create_pool(RedisSettings())
    now = datetime.now(tz=timezone.utc)  # This will work
    # now = datetime.now()  # This will not work
    for ii in range(0, 30, 10):
        tt = now + timedelta(seconds=ii)
        await redis.enqueue_job("task", tt, _defer_until=tt)


class WorkerSettings:
    functions = [task]


if __name__ == "__main__":
    loop = asyncio.get_event_loop()
    loop.run_until_complete(main())
```