### PR TITLE
Introduce default queue name to ArqRedis

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ History
 v0.19.1 (unreleased)
 ....................
 * fix timestamp issue in _defer_until without timezone offset, #182
+* Add ``default_queue_name`` to ``create_redis_pool`` and ``ArqRedis``.
+* ``Worker`` can retrieve the ``queue_name`` from the connection pool, if present.
 
 v0.19.0 (2020-04-24)
 ....................

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,8 +6,8 @@ History
 v0.19.1 (unreleased)
 ....................
 * fix timestamp issue in _defer_until without timezone offset, #182
-* Add ``default_queue_name`` to ``create_redis_pool`` and ``ArqRedis``.
-* ``Worker`` can retrieve the ``queue_name`` from the connection pool, if present.
+* Add ``default_queue_name`` to ``create_redis_pool`` and ``ArqRedis``, #191
+* ``Worker`` can retrieve the ``queue_name`` from the connection pool, if present
 
 v0.19.0 (2020-04-24)
 ....................

--- a/arq/utils.py
+++ b/arq/utils.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from time import time
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Optional, Sequence, overload
 
@@ -26,7 +26,7 @@ def to_unix_ms(dt: datetime) -> int:
 
 
 def ms_to_datetime(unix_ms: int) -> datetime:
-    return datetime.fromtimestamp(unix_ms / 1000)
+    return datetime.fromtimestamp(unix_ms / 1000, tz=timezone.utc)
 
 
 @overload

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -178,7 +178,7 @@ class Worker:
             if redis_pool is not None:
                 queue_name = redis_pool.default_queue_name
             else:
-                raise Exception('If queue_name is absent, redis_pool must be present.')
+                raise ValueError('If queue_name is absent, redis_pool must be present.')
         self.queue_name = queue_name
         self.cron_jobs: List[CronJob] = []
         if cron_jobs is not None:

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -152,7 +152,7 @@ class Worker:
         self,
         functions: Sequence[Union[Function, 'WorkerCoroutine']] = (),
         *,
-        queue_name: str = default_queue_name,
+        queue_name: Optional[str] = default_queue_name,
         cron_jobs: Optional[Sequence[CronJob]] = None,
         redis_settings: RedisSettings = None,
         redis_pool: ArqRedis = None,
@@ -174,6 +174,11 @@ class Worker:
         job_deserializer: Optional[Deserializer] = None,
     ):
         self.functions: Dict[str, Union[Function, CronJob]] = {f.name: f for f in map(func, functions)}
+        if queue_name is None:
+            if redis_pool is not None:
+                queue_name = redis_pool.default_queue_name
+            else:
+                raise Exception('If queue_name is absent, redis_pool must be present.')
         self.queue_name = queue_name
         self.cron_jobs: List[CronJob] = []
         if cron_jobs is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,7 @@ async def arq_redis_msgpack(loop):
 async def worker(arq_redis):
     worker_: Worker = None
 
-    def create(functions=[], burst=True, poll_delay=0, max_jobs=10, **kwargs):
+    def create(functions=[], burst=True, poll_delay=0, max_jobs=10, arq_redis=arq_redis, **kwargs):
         nonlocal worker_
         worker_ = Worker(
             functions=functions, redis_pool=arq_redis, burst=burst, poll_delay=poll_delay, max_jobs=max_jobs, **kwargs

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -5,7 +5,7 @@ import pytest
 from pytest_toolbox.comparison import CloseToNow
 
 from arq import Worker, func
-from arq.connections import ArqRedis
+from arq.connections import ArqRedis, RedisSettings, create_pool
 from arq.constants import default_queue_name, in_progress_key_prefix, job_key_prefix, result_key_prefix
 from arq.jobs import DeserializationError, Job, JobResult, JobStatus, deserialize_job_raw, serialize_result
 
@@ -75,6 +75,16 @@ async def test_enqueue_job(arq_redis: ArqRedis, worker, queue_name=default_queue
 
 async def test_enqueue_job_alt_queue(arq_redis: ArqRedis, worker):
     await test_enqueue_job(arq_redis, worker, queue_name='custom_queue')
+
+
+async def test_enqueue_job_nondefault_queue(worker):
+    """Test initializing arq_redis with a queue name, and the worker using it."""
+    arq_redis = await create_pool(RedisSettings(), default_queue_name='test_queue')
+    await test_enqueue_job(
+        arq_redis,
+        lambda functions, **_: worker(functions=functions, arq_redis=arq_redis, queue_name=None),
+        queue_name=None,
+    )
 
 
 async def test_cant_unpickle_at_all():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,7 +2,7 @@ import asyncio
 import dataclasses
 import logging
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timezone
 from random import shuffle
 from time import time
 
@@ -76,7 +76,7 @@ async def test_repeat_job(arq_redis: ArqRedis):
 
 
 async def test_defer_until(arq_redis: ArqRedis):
-    j1 = await arq_redis.enqueue_job('foobar', _job_id='job_id', _defer_until=datetime(2032, 1, 1))
+    j1 = await arq_redis.enqueue_job('foobar', _job_id='job_id', _defer_until=datetime(2032, 1, 1, tzinfo=timezone.utc))
     assert isinstance(j1, Job)
     score = await arq_redis.zscore(default_queue_name, 'job_id')
     assert score == 1_956_528_000_000


### PR DESCRIPTION
When using a single central Redis with multiple services, it's necessary to use different queues.

It's cumbersome to have to pass the queue name when enqueing jobs all the time, so we add the ability for an instance of ArqRedis to remember it.

We also make the worker be able to get the default queue name from ArqRedis, to not have to repeat ourselves.

This should be backwards compatible.

I've also fixed some timezone issues which were failing tests on my machine, which is not in UTC.