### PR TITLE
Remove gather

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,9 +5,10 @@ History
 
 v0.19.1 (unreleased)
 ....................
-* fix timestamp issue in _defer_until without timezone offset, #182
+* Fix timestamp issue in _defer_until without timezone offset, #182
 * Add ``default_queue_name`` to ``create_redis_pool`` and ``ArqRedis``, #191
 * ``Worker`` can retrieve the ``queue_name`` from the connection pool, if present
+* Fix potential race condition when starting jobs, #194
 
 v0.19.0 (2020-04-24)
 ....................

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -327,10 +327,12 @@ class Worker:
             await self.sem.acquire()
             in_progress_key = in_progress_key_prefix + job_id
             with await self.pool as conn:
-                await conn.unwatch()
-                await conn.watch(in_progress_key)
-                ongoing_exists = await conn.exists(in_progress_key)
-                score = await conn.zscore(self.queue_name, job_id)
+                pipe = conn.pipeline()
+                pipe.unwatch()
+                pipe.watch(in_progress_key)
+                pipe.exists(in_progress_key)
+                pipe.zscore(self.queue_name, job_id)
+                _, _, ongoing_exists, score = await pipe.execute()
                 if ongoing_exists or not score:
                     # job already started elsewhere, or already finished and removed from queue
                     self.sem.release()


### PR DESCRIPTION
`asyncio.gather` makes no guarantees about the order of execution of the coroutines it's given, and in this case ordering matters (the unwatch needs to execute before the watch, for example). So I've explicitly broken out the gather into individual awaits, then wrapped the awaits in a pipeline for less I/O.