### PR TITLE
Added queue_name attribute to JobResult

### DIFF
--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -50,6 +50,7 @@ class JobResult(JobDef):
     result: Any
     start_time: datetime
     finish_time: datetime
+    queue_name: str
     job_id: Optional[str] = None
 
 
@@ -172,6 +173,7 @@ def serialize_result(
     start_ms: int,
     finished_ms: int,
     ref: str,
+    queue_name: str,
     *,
     serializer: Optional[Serializer] = None,
 ) -> Optional[bytes]:
@@ -185,6 +187,7 @@ def serialize_result(
         'r': result,
         'st': start_ms,
         'ft': finished_ms,
+        'q': queue_name,
     }
     if serializer is None:
         serializer = pickle.dumps
@@ -247,6 +250,7 @@ def deserialize_result(r: bytes, *, deserializer: Optional[Deserializer] = None)
             result=d['r'],
             start_time=ms_to_datetime(d['st']),
             finish_time=ms_to_datetime(d['ft']),
+            queue_name=d['q'],
         )
     except Exception as e:
         raise DeserializationError('unable to deserialize job result') from e

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -250,7 +250,7 @@ def deserialize_result(r: bytes, *, deserializer: Optional[Deserializer] = None)
             result=d['r'],
             start_time=ms_to_datetime(d['st']),
             finish_time=ms_to_datetime(d['ft']),
-            queue_name=d['q'],
+            queue_name=d.get('q', '<unknown>'),
         )
     except Exception as e:
         raise DeserializationError('unable to deserialize job result') from e

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -384,6 +384,7 @@ class Worker:
                 finished_ms=timestamp_ms(),
                 ref=f'{job_id}:{function_name}',
                 serializer=self.job_serializer,
+                queue_name=self.queue_name,
             )
             await asyncio.shield(self.abort_job(job_id, result_data_))
 
@@ -431,6 +432,7 @@ class Worker:
                 start_ms,
                 timestamp_ms(),
                 ref,
+                self.queue_name,
                 serializer=self.job_serializer,
             )
             return await asyncio.shield(self.abort_job(job_id, result_data))
@@ -506,6 +508,7 @@ class Worker:
                 start_ms,
                 finished_ms,
                 ref,
+                self.queue_name,
                 serializer=self.job_serializer,
             )
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -43,6 +43,7 @@ async def test_enqueue_job(arq_redis: ArqRedis, worker, queue_name=default_queue
     assert r == 42
     assert JobStatus.complete == await j.status()
     info = await j.info()
+    expected_queue_name = queue_name or arq_redis.default_queue_name
     assert info == JobResult(
         job_try=1,
         function='foobar',
@@ -54,6 +55,7 @@ async def test_enqueue_job(arq_redis: ArqRedis, worker, queue_name=default_queue
         start_time=CloseToNow(),
         finish_time=CloseToNow(),
         score=None,
+        queue_name=expected_queue_name,
     )
     results = await arq_redis.all_job_results()
     assert results == [
@@ -68,6 +70,7 @@ async def test_enqueue_job(arq_redis: ArqRedis, worker, queue_name=default_queue
             start_time=CloseToNow(),
             finish_time=CloseToNow(),
             score=None,
+            queue_name=expected_queue_name,
             job_id=j.job_id,
         )
     ]
@@ -92,9 +95,9 @@ async def test_cant_unpickle_at_all():
         def __getstate__(self):
             raise TypeError("this doesn't pickle")
 
-    r1 = serialize_result('foobar', (1,), {}, 1, 123, True, Foobar(), 123, 123, 'testing')
+    r1 = serialize_result('foobar', (1,), {}, 1, 123, True, Foobar(), 123, 123, 'testing', 'test-queue')
     assert isinstance(r1, bytes)
-    r2 = serialize_result('foobar', (Foobar(),), {}, 1, 123, True, Foobar(), 123, 123, 'testing')
+    r2 = serialize_result('foobar', (Foobar(),), {}, 1, 123, True, Foobar(), 123, 123, 'testing', 'test-queue')
     assert r2 is None
 
 
@@ -106,10 +109,23 @@ async def test_custom_serializer():
     def custom_serializer(x):
         return b'0123456789'
 
-    r1 = serialize_result('foobar', (1,), {}, 1, 123, True, Foobar(), 123, 123, 'testing', serializer=custom_serializer)
+    r1 = serialize_result(
+        'foobar', (1,), {}, 1, 123, True, Foobar(), 123, 123, 'testing', 'test-queue', serializer=custom_serializer
+    )
     assert r1 == b'0123456789'
     r2 = serialize_result(
-        'foobar', (Foobar(),), {}, 1, 123, True, Foobar(), 123, 123, 'testing', serializer=custom_serializer
+        'foobar',
+        (Foobar(),),
+        {},
+        1,
+        123,
+        True,
+        Foobar(),
+        123,
+        123,
+        'testing',
+        'test-queue',
+        serializer=custom_serializer,
     )
     assert r2 == b'0123456789'
 


### PR DESCRIPTION
This pull request addresses issue #161 

I didn't feel like I needed to add any new tests as modifying the existing tests checks that the attribute exists in the result.

Also technically I could add the queue_name attribute in the JobDef as well but I don't really see a use for that yet but happy to add it there as well.