### PR TITLE
Cron refactor

### DIFF
--- a/arq/constants.py
+++ b/arq/constants.py
@@ -4,3 +4,4 @@ in_progress_key_prefix = 'arq:in-progress:'
 result_key_prefix = 'arq:result:'
 retry_key_prefix = 'arq:retry:'
 health_check_key_suffix = ':health-check'
+keep_cronjob_progress = 1.0

--- a/arq/constants.py
+++ b/arq/constants.py
@@ -4,4 +4,6 @@ in_progress_key_prefix = 'arq:in-progress:'
 result_key_prefix = 'arq:result:'
 retry_key_prefix = 'arq:retry:'
 health_check_key_suffix = ':health-check'
-keep_cronjob_progress = 1.0
+# how long to keep the "in_progress" key after a cron job ends to prevent the job duplication
+# this can be a long time since each cron job has an ID that is unique for the intended execution time
+keep_cronjob_progress = 60

--- a/arq/cron.py
+++ b/arq/cron.py
@@ -108,9 +108,9 @@ class CronJob:
     max_tries: Optional[int]
     next_run: Optional[datetime] = None
 
-    def set_next(self, dt: datetime) -> None:
+    def calculate_next(self, prev_run: datetime) -> None:
         self.next_run = next_cron(
-            dt,
+            prev_run,
             month=self.month,
             day=self.day,
             weekday=self.weekday,

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -588,7 +588,7 @@ class Worker:
         cron_window_size = max(self.poll_delay_s, 0.5)  # Clamp the cron delay to 0.5
         await self.run_cron(now, cron_window_size)
 
-    async def run_cron(self, n: datetime, delay: float, num_windows=2) -> None:
+    async def run_cron(self, n: datetime, delay: float, num_windows: int = 2) -> None:
         job_futures = set()
 
         cron_delay = timedelta(seconds=delay * num_windows)

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -418,7 +418,7 @@ class Worker:
         if hasattr(function, 'next_run'):
             # cron_job
             ref = function_name
-            keep_in_progress = keep_cronjob_progress
+            keep_in_progress: Optional[float] = keep_cronjob_progress
         else:
             ref = f'{job_id}:{function_name}'
             keep_in_progress = None

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -89,9 +89,10 @@ async def foobar(ctx):
     return 42
 
 
-async def test_job_successful(worker, caplog):
+@pytest.mark.parametrize('poll_delay', [0.0, 0.5, 0.9])
+async def test_job_successful(worker, caplog, poll_delay):
     caplog.set_level(logging.INFO)
-    worker: Worker = worker(cron_jobs=[cron(foobar, hour=1, run_at_startup=True)], poll_delay=0.5)
+    worker: Worker = worker(cron_jobs=[cron(foobar, hour=1, run_at_startup=True)], poll_delay=poll_delay)
     await worker.main()
     assert worker.jobs_complete == 1
     assert worker.jobs_failed == 0

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -91,7 +91,7 @@ async def foobar(ctx):
 
 async def test_job_successful(worker, caplog):
     caplog.set_level(logging.INFO)
-    worker: Worker = worker(cron_jobs=[cron(foobar, hour=1, run_at_startup=True)])
+    worker: Worker = worker(cron_jobs=[cron(foobar, hour=1, run_at_startup=True)], poll_delay=0.5)
     await worker.main()
     assert worker.jobs_complete == 1
     assert worker.jobs_failed == 0
@@ -103,7 +103,9 @@ async def test_job_successful(worker, caplog):
 
 async def test_job_successful_on_specific_queue(worker, caplog):
     caplog.set_level(logging.INFO)
-    worker: Worker = worker(queue_name='arq:test-cron-queue', cron_jobs=[cron(foobar, hour=1, run_at_startup=True)])
+    worker: Worker = worker(
+        queue_name='arq:test-cron-queue', cron_jobs=[cron(foobar, hour=1, run_at_startup=True)], poll_delay=0.5
+    )
     await worker.main()
     assert worker.jobs_complete == 1
     assert worker.jobs_failed == 0

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -6,6 +6,7 @@ from random import random
 import pytest
 
 from arq import Worker
+from arq.constants import in_progress_key_prefix
 from arq.cron import cron, next_cron
 
 
@@ -90,7 +91,7 @@ async def foobar(ctx):
 
 
 @pytest.mark.parametrize('poll_delay', [0.0, 0.5, 0.9])
-async def test_job_successful(worker, caplog, poll_delay):
+async def test_job_successful(worker, caplog, arq_redis, poll_delay):
     caplog.set_level(logging.INFO)
     worker: Worker = worker(cron_jobs=[cron(foobar, hour=1, run_at_startup=True)], poll_delay=poll_delay)
     await worker.main()
@@ -100,6 +101,11 @@ async def test_job_successful(worker, caplog, poll_delay):
 
     log = re.sub(r'(\d+).\d\ds', r'\1.XXs', '\n'.join(r.message for r in caplog.records))
     assert '  0.XXs → cron:foobar()\n  0.XXs ← cron:foobar ● 42' in log
+
+    # Assert the in-progress key still exists.
+    keys = await arq_redis.keys(in_progress_key_prefix + '*')
+    assert len(keys) == 1
+    assert await arq_redis.pttl(keys[0]) > 0.0
 
 
 async def test_job_successful_on_specific_queue(worker, caplog):


### PR DESCRIPTION
This is an attempt of fixing #196.

Instead of enqueueing a cron job after the cron time, we enqueue before.

This makes the cron job run closer to its schedule, and the enqueues are idempotent (it's the same if one worker enqueues or 20).

A more detailed explanation follows.

We introduce the concept of a cron scheduling window, that's tied to the polling delay (the polling delay default is 0.5s), except the cron scheduling window length is clamped at a minimum value of 0.5s. Anyway, let's assume the poll delay is 0.5s, and hence the cron window length is 0.5s.

We start keeping track of the exact time of the last heartbeat.

On each heartbeat, we iterate over the defined cronjobs, choose cronjobs that are inside the window and enqueue them. The window is defined as starting at (last_heartbeat_time + cron window length), and ending at (now + cron window length).

Also, for cronjobs that finish successfully, we keep the in-progress key in Redis for 1 second (instead of deleting it outright). This is to stop the cronjob being enqueued again by workers with skewed clocks, and to handle edge cases. (We might want to use a larger buffer than 1s.)