### PR TITLE
Fix issue where pool serializer would not be same as worker

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -276,7 +276,9 @@ class Worker:
 
     async def main(self) -> None:
         if self._pool is None:
-            self._pool = await create_pool(self.redis_settings)
+            self._pool = await create_pool(
+                self.redis_settings, job_deserializer=self.job_deserializer, job_serializer=self.job_serializer
+            )
 
         logger.info('Starting worker for %d functions: %s', len(self.functions), ', '.join(self.functions))
         await log_redis_info(self.pool, logger.info)


### PR DESCRIPTION
The issue was encountered when initializing redis through RedisSettings
instead of explicitly setting the arq connection pool.

If cron was used and `job_serializer` was not `pickle` the cron item would be
serialized with pickle.dumps and then attempted to deserialize with the configured
`job_deserializer` in worker, causing an error.

Quick workaround is to create the pool yourself, otherwise always use the
pickle serializer.