### PR TITLE
Add method to cancel jobs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,10 +5,12 @@ History
 
 v0.19.1 (unreleased)
 ....................
+
 * fix timestamp issue in _defer_until without timezone offset, #182
 * add option to disable signal handler registration from running inside other frameworks, #183
-* Add ``default_queue_name`` to ``create_redis_pool`` and ``ArqRedis``, #191
+* add ``default_queue_name`` to ``create_redis_pool`` and ``ArqRedis``, #191
 * ``Worker`` can retrieve the ``queue_name`` from the connection pool, if present
+* fix potential race condition when starting jobs, #194
 
 v0.19.0 (2020-04-24)
 ....................

--- a/arq/constants.py
+++ b/arq/constants.py
@@ -3,7 +3,9 @@ job_key_prefix = 'arq:job:'
 in_progress_key_prefix = 'arq:in-progress:'
 result_key_prefix = 'arq:result:'
 retry_key_prefix = 'arq:retry:'
-abort_key_prefix = 'arq:abort:'
+abort_jobs_ss = 'arq:abort'
+# age of items in the abort_key sorted set after which they're deleted
+abort_job_max_age = 60
 health_check_key_suffix = ':health-check'
 # how long to keep the "in_progress" key after a cron job ends to prevent the job duplication
 # this can be a long time since each cron job has an ID that is unique for the intended execution time

--- a/arq/constants.py
+++ b/arq/constants.py
@@ -1,6 +1,7 @@
-default_queue_name = 'arq:queue'
-job_key_prefix = 'arq:job:'
-in_progress_key_prefix = 'arq:in-progress:'
-result_key_prefix = 'arq:result:'
-retry_key_prefix = 'arq:retry:'
-health_check_key_suffix = ':health-check'
+default_queue_name = "arq:queue"
+job_key_prefix = "arq:job:"
+in_progress_key_prefix = "arq:in-progress:"
+result_key_prefix = "arq:result:"
+retry_key_prefix = "arq:retry:"
+abort_key_prefix = "arq:abort:"
+health_check_key_suffix = ":health-check"

--- a/arq/constants.py
+++ b/arq/constants.py
@@ -1,7 +1,7 @@
-default_queue_name = "arq:queue"
-job_key_prefix = "arq:job:"
-in_progress_key_prefix = "arq:in-progress:"
-result_key_prefix = "arq:result:"
-retry_key_prefix = "arq:retry:"
-abort_key_prefix = "arq:abort:"
-health_check_key_suffix = ":health-check"
+default_queue_name = 'arq:queue'
+job_key_prefix = 'arq:job:'
+in_progress_key_prefix = 'arq:in-progress:'
+result_key_prefix = 'arq:result:'
+retry_key_prefix = 'arq:retry:'
+abort_key_prefix = 'arq:abort:'
+health_check_key_suffix = ':health-check'

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -89,6 +89,8 @@ class Job:
                     return result
                 elif isinstance(result, (Exception, asyncio.CancelledError)):
                     raise result
+                elif result is None:
+                    return None
                 else:
                     raise SerializationError(result)
             if timeout is not None and delay > timeout:

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -8,7 +8,13 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 from aioredis import Redis
 
-from .constants import default_queue_name, in_progress_key_prefix, job_key_prefix, result_key_prefix
+from .constants import (
+    default_queue_name,
+    in_progress_key_prefix,
+    job_key_prefix,
+    result_key_prefix,
+    abort_key_prefix,
+)
 from .utils import ms_to_datetime, poll, timestamp_ms
 
 logger = logging.getLogger('arq.jobs')
@@ -130,6 +136,24 @@ class Job:
             if not score:
                 return JobStatus.not_found
             return JobStatus.deferred if score > timestamp_ms() else JobStatus.queued
+
+    async def abort(self, timeout: Optional[float] = None, *, pole_delay: float = 0.5, key_expire: Optional[int] = 10) -> bool:
+        """
+        Abort the job.
+
+        :param timeout: maximum time to wait for the job result before raising ``TimeoutError``, will wait forever on None
+        :param pole_delay: how often to poll redis for the job result
+        :param key_expire: how long until the abort key expires
+        :return: True if the job cancelled properly, false otherwise.
+        """
+        await self._redis.set(
+            f'{abort_key_prefix}{self.job_id}', b'1', expire=key_expire
+        )
+        try:
+            await self.result(timeout=timeout, pole_delay=pole_delay)
+            return False
+        except asyncio.CancelledError:
+            return True
 
     def __repr__(self) -> str:
         return f'<arq job {self.job_id}>'

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -8,13 +8,7 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 from aioredis import Redis
 
-from .constants import (
-    default_queue_name,
-    in_progress_key_prefix,
-    job_key_prefix,
-    result_key_prefix,
-    abort_key_prefix,
-)
+from .constants import abort_key_prefix, default_queue_name, in_progress_key_prefix, job_key_prefix, result_key_prefix
 from .utils import ms_to_datetime, poll, timestamp_ms
 
 logger = logging.getLogger('arq.jobs')
@@ -137,18 +131,19 @@ class Job:
                 return JobStatus.not_found
             return JobStatus.deferred if score > timestamp_ms() else JobStatus.queued
 
-    async def abort(self, timeout: Optional[float] = None, *, pole_delay: float = 0.5, key_expire: Optional[int] = 10) -> bool:
+    async def abort(
+        self, timeout: Optional[float] = None, *, pole_delay: float = 0.5, key_expire: Optional[int] = 10
+    ) -> bool:
         """
         Abort the job.
 
-        :param timeout: maximum time to wait for the job result before raising ``TimeoutError``, will wait forever on None
+        :param timeout: maximum time to wait for the job result before raising ``TimeoutError``,
+        will wait forever on None
         :param pole_delay: how often to poll redis for the job result
         :param key_expire: how long until the abort key expires
         :return: True if the job aborted properly, False otherwise
         """
-        await self._redis.set(
-            f'{abort_key_prefix}{self.job_id}', b'1', expire=key_expire
-        )
+        await self._redis.set(f'{abort_key_prefix}{self.job_id}', b'1', expire=key_expire)
         try:
             await self.result(timeout=timeout, pole_delay=pole_delay)
             return False

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -86,7 +86,7 @@ class Job:
                 result = info.result
                 if info.success:
                     return result
-                elif isinstance(result, Exception) or isinstance(result, asyncio.CancelledError):
+                elif isinstance(result, (Exception, asyncio.CancelledError)):
                     raise result
                 else:
                     raise SerializationError(result)
@@ -146,9 +146,10 @@ class Job:
         await self._redis.set(f'{abort_key_prefix}{self.job_id}', b'1', expire=key_expire)
         try:
             await self.result(timeout=timeout, pole_delay=pole_delay)
-            return False
         except asyncio.CancelledError:
             return True
+        else:
+            return False
 
     def __repr__(self) -> str:
         return f'<arq job {self.job_id}>'

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -89,8 +89,6 @@ class Job:
                     return result
                 elif isinstance(result, (Exception, asyncio.CancelledError)):
                     raise result
-                elif result is None:
-                    return None
                 else:
                     raise SerializationError(result)
             if timeout is not None and delay > timeout:

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -144,7 +144,7 @@ class Job:
         :param timeout: maximum time to wait for the job result before raising ``TimeoutError``, will wait forever on None
         :param pole_delay: how often to poll redis for the job result
         :param key_expire: how long until the abort key expires
-        :return: True if the job cancelled properly, false otherwise.
+        :return: True if the job aborted properly, False otherwise
         """
         await self._redis.set(
             f'{abort_key_prefix}{self.job_id}', b'1', expire=key_expire

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -147,6 +147,7 @@ class Worker:
     :param health_check_key: redis key under which health check is set
     :param ctx: dictionary to hold extra user defined state
     :param retry_jobs: whether to retry jobs on Retry or CancelledError or not
+    :param abort_jobs: whether to cancel jobs on a call to :func:`arq.jobs.Job.abort`
     :param max_burst_jobs: the maximum number of jobs to process in burst mode (disabled with negative values)
     :param job_serializer: a function that serializes Python objects to bytes, defaults to pickle.dumps
     :param job_deserializer: a function that deserializes bytes into Python objects, defaults to pickle.loads

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -175,7 +175,7 @@ class Worker:
         health_check_key: Optional[str] = None,
         ctx: Optional[Dict[Any, Any]] = None,
         retry_jobs: bool = True,
-        abort_jobs: bool = False,
+        abort_jobs: bool = True,
         max_burst_jobs: int = -1,
         job_serializer: Optional[Serializer] = None,
         job_deserializer: Optional[Deserializer] = None,

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -559,7 +559,7 @@ class Worker:
             if finish:
                 if result_data:
                     tr.setex(result_key_prefix + job_id, result_timeout_s, result_data)
-                delete_keys += [retry_key_prefix + job_id, job_key_prefix + job_id]
+                delete_keys += [retry_key_prefix + job_id, job_key_prefix + job_id, abort_key_prefix + job_id]
                 tr.zrem(self.queue_name, job_id)
             elif incr_score:
                 tr.zincrby(self.queue_name, incr_score, job_id)
@@ -570,7 +570,7 @@ class Worker:
         with await self.pool as conn:
             await conn.unwatch()
             tr = conn.multi_exec()
-            tr.delete(retry_key_prefix + job_id, in_progress_key_prefix + job_id, job_key_prefix + job_id)
+            tr.delete(retry_key_prefix + job_id, in_progress_key_prefix + job_id, job_key_prefix + job_id, abort_key_prefix + job_id)
             tr.zrem(self.queue_name, job_id)
             # result_data would only be None if serializing the result fails
             if result_data is not None and self.keep_result_s > 0:  # pragma: no branch

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -175,7 +175,7 @@ class Worker:
         health_check_key: Optional[str] = None,
         ctx: Optional[Dict[Any, Any]] = None,
         retry_jobs: bool = True,
-        abort_jobs: bool = False,
+        allow_abort_jobs: bool = False,
         max_burst_jobs: int = -1,
         job_serializer: Optional[Serializer] = None,
         job_deserializer: Optional[Deserializer] = None,
@@ -231,7 +231,7 @@ class Worker:
         self.on_stop: Optional[Callable[[Signals], None]] = None
         # whether or not to retry jobs on Retry and CancelledError
         self.retry_jobs = retry_jobs
-        self.abort_jobs = abort_jobs
+        self.allow_abort_jobs = allow_abort_jobs
         self._aborting_tasks: Set[str] = set()
         self.max_burst_jobs = max_burst_jobs
         self.job_serializer = job_serializer
@@ -321,7 +321,7 @@ class Worker:
 
         await self.start_jobs(job_ids)
 
-        if self.abort_jobs:
+        if self.allow_abort_jobs:
             await self._scan_abort_jobs()
 
         for job_id, t in list(self.tasks.items()):
@@ -329,7 +329,7 @@ class Worker:
                 del self.tasks[job_id]
                 # required to make sure errors in run_job get propagated
                 t.result()
-            elif self.abort_jobs and job_id in self._aborting_tasks:
+            elif self.allow_abort_jobs and job_id in self._aborting_tasks:
                 t.cancel()
 
         await self.heart_beat()

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -24,6 +24,7 @@ from .constants import (
     job_key_prefix,
     result_key_prefix,
     retry_key_prefix,
+    abort_key_prefix,
 )
 from .utils import args_to_string, ms_to_datetime, poll, timestamp_ms, to_ms, to_seconds, to_unix_ms, truncate
 
@@ -173,6 +174,7 @@ class Worker:
         health_check_key: Optional[str] = None,
         ctx: Optional[Dict[Any, Any]] = None,
         retry_jobs: bool = True,
+        abort_jobs: bool = False,
         max_burst_jobs: int = -1,
         job_serializer: Optional[Serializer] = None,
         job_deserializer: Optional[Deserializer] = None,
@@ -210,7 +212,7 @@ class Worker:
             self.redis_settings: Optional[RedisSettings] = redis_settings or RedisSettings()
         else:
             self.redis_settings = None
-        self.tasks: List[asyncio.Task[Any]] = []
+        self.tasks: Dict[asyncio.Task[Any]] = {}
         self.main_task: Optional[asyncio.Task[None]] = None
         self.loop = asyncio.get_event_loop()
         self.ctx = ctx or {}
@@ -228,6 +230,8 @@ class Worker:
         self.on_stop: Optional[Callable[[Signals], None]] = None
         # whether or not to retry jobs on Retry and CancelledError
         self.retry_jobs = retry_jobs
+        self.abort_jobs = abort_jobs
+        self._aborting_tasks = set()
         self.max_burst_jobs = max_burst_jobs
         self.job_serializer = job_serializer
         self.job_deserializer = job_deserializer
@@ -289,11 +293,11 @@ class Worker:
 
             if self.burst:
                 if 0 <= self.max_burst_jobs <= self._jobs_started():
-                    await asyncio.gather(*self.tasks)
+                    await asyncio.gather(*self.tasks.values())
                     return None
                 queued_jobs = await self.pool.zcard(self.queue_name)
                 if queued_jobs == 0:
-                    await asyncio.gather(*self.tasks)
+                    await asyncio.gather(*self.tasks.values())
                     return None
 
     async def _poll_iteration(self) -> None:
@@ -316,13 +320,34 @@ class Worker:
 
         await self.start_jobs(job_ids)
 
-        for t in self.tasks:
+        if self.abort_jobs:
+            await self._scan_abort_jobs()
+
+        for job_id, t in list(self.tasks.items()):
             if t.done():
-                self.tasks.remove(t)
+                del self.tasks[job_id]
                 # required to make sure errors in run_job get propagated
                 t.result()
+            elif job_id in self._aborting_tasks:
+                t.cancel()
 
         await self.heart_beat()
+
+    async def _scan_abort_jobs(self):
+        orphaned_job_keys = []
+        cursor = b'0'
+        abort_key_len = len(abort_key_prefix), 
+        abort_key_match = f'{abort_key_prefix}*'
+        while cursor:
+            cursor, keys = await self.pool.scan(cursor, match=abort_key_match)
+            for job_key in keys:
+                job_id = job_key[abort_key_len:]
+                if job_id in self.tasks:
+                    self._aborting_tasks.add(job_id)
+                else:
+                    orphaned_job_keys.append(job_key)
+        if orphaned_job_keys:
+            await self.pool.delete(*orphaned_job_keys)
 
     async def start_jobs(self, job_ids: List[str]) -> None:
         """
@@ -357,7 +382,7 @@ class Worker:
                 else:
                     t = self.loop.create_task(self.run_job(job_id, score))
                     t.add_done_callback(lambda _: self.sem.release())
-                    self.tasks.append(t)
+                    self.tasks[job_id] = t
 
     async def run_job(self, job_id: str, score: int) -> None:  # noqa: C901
         start_ms = timestamp_ms()
@@ -469,13 +494,20 @@ class Worker:
         except Exception as e:
             finished_ms = timestamp_ms()
             t = (finished_ms - start_ms) / 1000
+            was_cancelled = isinstance(e, asyncio.CancelledError)
             if self.retry_jobs and isinstance(e, Retry):
                 incr_score = e.defer_score
                 logger.info('%6.2fs ↻ %s retrying job in %0.2fs', t, ref, (e.defer_score or 0) / 1000)
                 if e.defer_score:
                     incr_score = e.defer_score + (timestamp_ms() - score)
                 self.jobs_retried += 1
-            elif self.retry_jobs and isinstance(e, (asyncio.CancelledError, RetryJob)):
+            elif job_id in self._aborting_tasks and was_cancelled:
+                logger.info('%6.2fs 🛇  %s aborted', t, ref)
+                result = e
+                finish = True
+                self._aborting_tasks.remove(job_id)
+                self.jobs_failed += 1
+            elif self.retry_jobs and was_cancelled:
                 logger.info('%6.2fs ↻ %s cancelled, will be run again', t, ref)
                 self.jobs_retried += 1
             else:
@@ -572,7 +604,7 @@ class Worker:
         if (now_ts - self._last_health_check) < self.health_check_interval:
             return
         self._last_health_check = now_ts
-        pending_tasks = sum(not t.done() for t in self.tasks)
+        pending_tasks = sum(not t.done() for t in self.tasks.values())
         queued = await self.pool.zcard(self.queue_name)
         info = (
             f'{datetime.now():%b-%d %H:%M:%S} j_complete={self.jobs_complete} j_failed={self.jobs_failed} '
@@ -605,7 +637,7 @@ class Worker:
             self.jobs_retried,
             len(self.tasks),
         )
-        for t in self.tasks:
+        for t in self.tasks.values():
             if not t.done():
                 t.cancel()
         self.main_task and self.main_task.cancel()
@@ -616,7 +648,7 @@ class Worker:
             self.handle_sig(signal.SIGUSR1)
         if not self._pool:
             return
-        await asyncio.gather(*self.tasks)
+        await asyncio.gather(*self.tasks.values())
         await self.pool.delete(self.health_check_key)
         if self.on_shutdown:
             await self.on_shutdown(self.ctx)
@@ -627,7 +659,7 @@ class Worker:
     def __repr__(self) -> str:
         return (
             f'<Worker j_complete={self.jobs_complete} j_failed={self.jobs_failed} j_retried={self.jobs_retried} '
-            f'j_ongoing={sum(not t.done() for t in self.tasks)}>'
+            f'j_ongoing={sum(not t.done() for t in self.tasks.values())}>'
         )
 
 

--- a/docs/examples/job_abort.py
+++ b/docs/examples/job_abort.py
@@ -1,0 +1,58 @@
+import asyncio
+
+from datetime import datetime
+
+from arq import create_pool, cron, func
+from arq.connections import RedisSettings
+# requires `pip install devtools`, used for pretty printing of job info
+from devtools import debug
+
+
+async def the_task(ctx):
+    print('running the task')
+    return 42
+
+async def cron_the_task(ctx, crontab, funcname):
+    crn = cron(cron_the_task, **crontab)
+    redis = ctx['redis']
+    while True:
+        n = datetime.now()
+        crn.set_next(n)
+        wait = (crn.next_run - n).total_seconds()
+        print(f'{n}: need to wait till {wait} for next activation')
+        await asyncio.sleep(wait)
+        await redis.enqueue_job(funcname)
+
+async def main():
+    redis = await create_pool(RedisSettings())
+
+    job = await redis.enqueue_job(
+        'cron_a_task', {'hour': 19, 'minute': 23}, 'the_task'
+    )
+    await asyncio.sleep(30)
+    # stop the crontab task scheduler
+    print('crontab cancelled')
+    await job.abort()
+    """
+    >  19:22:43: Starting worker for 2 functions: cron_a_task, the_task
+    >  19:22:43: redis_version=5.0.5 mem_usage=1.16M clients_connected=18 db_keys=0
+    >  19:22:44:   0.15s → 754fb45d0aeb49ca8f295e1895de8c45:cron_a_task({'hour': 19, 'minute': 23}, 'the_task')
+    >  2020-03-26 19:22:44.039359: need to wait till 16.084097 for next activation
+    >  2020-03-26 19:23:00.129139: need to wait till 86399.994317 for next activation
+    >  19:23:00:   0.47s → ad77622cf26c4b38b52a757f635e0c70:the_task()
+    >  running the task
+    >  19:23:00:   0.00s ← ad77622cf26c4b38b52a757f635e0c70:the_task ● 42
+    >  19:23:14:  30.10s 🛇  754fb45d0aeb49ca8f295e1895de8c45:cron_a_task aborted
+    """
+
+class WorkerSettings:
+    # default timeout is 300s, timeout=0 disable it and wait till job.abort() is called
+    functions = [
+        func(cron_the_task, name='cron_a_task', timeout=0), 
+        the_task
+    ]
+    abort_jobs = True
+
+if __name__ == '__main__':
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())

--- a/docs/examples/job_abort.py
+++ b/docs/examples/job_abort.py
@@ -1,60 +1,25 @@
 import asyncio
-
-from datetime import datetime
-
-from arq import create_pool, cron, func
+from arq import create_pool
 from arq.connections import RedisSettings
-# requires `pip install devtools`, used for pretty printing of job info
-from devtools import debug
 
 
-async def the_task(ctx):
-    print('running the task')
-    return 42
+async def do_stuff(ctx):
+    print('doing stuff...')
+    await asyncio.sleep(10)
+    return 'stuff done'
 
-async def cron_the_task(ctx, crontab, funcname):
-    crn = cron(cron_the_task, **crontab)
-    redis = ctx['redis']
-    while True:
-        n = datetime.now()
-        crn.set_next(n)
-        wait = (crn.next_run - n).total_seconds()
-        print(f'{n}: need to wait till {wait} for next activation')
-        await asyncio.sleep(wait)
-        await redis.enqueue_job(funcname)
 
 async def main():
     redis = await create_pool(RedisSettings())
+    job = await redis.enqueue_job('do_stuff')
+    await asyncio.sleep(1)
+    await job.abort()
 
-    job = await redis.enqueue_job(
-        'cron_a_task', {'hour': 19, 'minute': 23}, 'the_task'
-    )
-    await asyncio.sleep(30)
-    # stop the crontab task scheduler
-    success = await job.abort()
-    if success:
-        print('crontab cancelled successfully')
-    else:
-        print('crontab not cancelled successfully')
-    """
-    >  19:22:43: Starting worker for 2 functions: cron_a_task, the_task
-    >  19:22:43: redis_version=5.0.5 mem_usage=1.16M clients_connected=18 db_keys=0
-    >  19:22:44:   0.15s → 754fb45d0aeb49ca8f295e1895de8c45:cron_a_task({'hour': 19, 'minute': 23}, 'the_task')
-    >  2020-03-26 19:22:44.039359: need to wait till 16.084097 for next activation
-    >  2020-03-26 19:23:00.129139: need to wait till 86399.994317 for next activation
-    >  19:23:00:   0.47s → ad77622cf26c4b38b52a757f635e0c70:the_task()
-    >  running the task
-    >  19:23:00:   0.00s ← ad77622cf26c4b38b52a757f635e0c70:the_task ● 42
-    >  19:23:14:  30.10s 🛇  754fb45d0aeb49ca8f295e1895de8c45:cron_a_task aborted
-    """
 
 class WorkerSettings:
-    # default timeout is 300s, timeout=0 disable it and wait till job.abort() is called
-    functions = [
-        func(cron_the_task, name='cron_a_task', timeout=0), 
-        the_task
-    ]
+    functions = [do_stuff]
+    allow_abort_jobs = True
+
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())

--- a/docs/examples/job_abort.py
+++ b/docs/examples/job_abort.py
@@ -31,8 +31,11 @@ async def main():
     )
     await asyncio.sleep(30)
     # stop the crontab task scheduler
-    print('crontab cancelled')
-    await job.abort()
+    success = await job.abort()
+    if success:
+        print('crontab cancelled successfully')
+    else:
+        print('crontab not cancelled successfully')
     """
     >  19:22:43: Starting worker for 2 functions: cron_a_task, the_task
     >  19:22:43: redis_version=5.0.5 mem_usage=1.16M clients_connected=18 db_keys=0
@@ -51,7 +54,6 @@ class WorkerSettings:
         func(cron_the_task, name='cron_a_task', timeout=0), 
         the_task
     ]
-    abort_jobs = True
 
 if __name__ == '__main__':
     loop = asyncio.get_event_loop()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -171,6 +171,9 @@ To abort a job, call :func:`arq.job.Job.abort`. (Note for the :func:`arq.job.Job
 have any effect, you need to set ``allow_abort_jobs`` to ``True`` on the worker, this is for performance reason.
 ``allow_abort_jobs=True`` may become the default in future)
 
+:func:`arq.job.Job.abort` will abort a job if it's already running or prevent it being run if it's currently
+in the queue.
+
 .. literalinclude:: examples/job_abort.py
 
 Health checks

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -167,7 +167,9 @@ optionally with a duration to defer rerunning the jobs by:
 
 .. literalinclude:: examples/retry.py
 
-To cancel a job, call :func:`arq.job.Job.cancel`.
+To abort a job, call :func:`arq.job.Job.abort`. (Note for the :func:`arq.job.Job.abort` method to
+have any effect, you need to set ``allow_abort_jobs`` to ``True`` on the worker, this is for performance reason.
+``allow_abort_jobs=True`` may become the default in future)
 
 .. literalinclude:: examples/job_abort.py
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -167,7 +167,7 @@ optionally with a duration to defer rerunning the jobs by:
 
 .. literalinclude:: examples/retry.py
 
-You can also abort long running tasks by passing ``abort_jobs=True`` to ``WorkerSettings``.
+To cancel a job, call :func:`arq.job.Job.cancel`.
 
 .. literalinclude:: examples/job_abort.py
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -167,6 +167,10 @@ optionally with a duration to defer rerunning the jobs by:
 
 .. literalinclude:: examples/retry.py
 
+You can also abort long running tasks by passing ``abort_jobs=True`` to ``WorkerSettings``.
+
+.. literalinclude:: examples/job_abort.py
+
 Health checks
 .............
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         arq=arq.cli:cli
     """,
     install_requires=[
-        'async-timeout>=3.0.0',
         'aioredis>=1.1.0',
         'click>=6.7',
         'pydantic>=1',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,7 +4,7 @@ flake8==3.7.9
 flake8-quotes==3
 isort==4.3.21
 msgpack==0.6.1
-mypy==0.790
+mypy==0.812
 pycodestyle==2.5.0
 pyflakes==2.1.1
 pytest==5.3.5

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11,7 +11,7 @@ import pytest
 from aioredis import create_redis_pool
 
 from arq.connections import ArqRedis
-from arq.constants import abort_jobs_ss, default_queue_name, health_check_key_suffix, job_key_prefix
+from arq.constants import default_queue_name, health_check_key_suffix, job_key_prefix
 from arq.jobs import Job, JobStatus
 from arq.worker import (
     FailedJobs,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11,7 +11,7 @@ import pytest
 from aioredis import create_redis_pool
 
 from arq.connections import ArqRedis
-from arq.constants import default_queue_name, health_check_key_suffix, job_key_prefix, abort_jobs_ss
+from arq.constants import abort_jobs_ss, default_queue_name, health_check_key_suffix, job_key_prefix
 from arq.jobs import Job, JobStatus
 from arq.worker import (
     FailedJobs,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -95,7 +95,7 @@ async def test_handle_no_sig(caplog):
     caplog.set_level(logging.INFO)
     worker = Worker([foobar], handle_signals=False)
     worker.main_task = MagicMock()
-    worker.tasks = [MagicMock(done=MagicMock(return_value=True)), MagicMock(done=MagicMock(return_value=False))]
+    worker.tasks = {0: MagicMock(done=MagicMock(return_value=True)), 1: MagicMock(done=MagicMock(return_value=False))}
 
     assert len(caplog.records) == 0
     await worker.close()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11,7 +11,7 @@ import pytest
 from aioredis import create_redis_pool
 
 from arq.connections import ArqRedis
-from arq.constants import default_queue_name, health_check_key_suffix, job_key_prefix
+from arq.constants import default_queue_name, health_check_key_suffix, job_key_prefix, abort_key_prefix
 from arq.jobs import Job, JobStatus
 from arq.worker import (
     FailedJobs,
@@ -76,7 +76,7 @@ async def test_handle_sig(caplog):
     caplog.set_level(logging.INFO)
     worker = Worker([foobar])
     worker.main_task = MagicMock()
-    worker.tasks = [MagicMock(done=MagicMock(return_value=True)), MagicMock(done=MagicMock(return_value=False))]
+    worker.tasks = {0: MagicMock(done=MagicMock(return_value=True)), 1: MagicMock(done=MagicMock(return_value=False))}
 
     assert len(caplog.records) == 0
     worker.handle_sig(signal.SIGINT)
@@ -717,3 +717,28 @@ async def test_multi_exec(arq_redis: ArqRedis, worker, caplog):
     # debug(caplog.text)
     assert 'multi-exec error, job testing already started elsewhere' in caplog.text
     assert 'WatchVariableError' not in caplog.text
+
+
+async def test_abort_job(arq_redis: ArqRedis, worker, caplog, loop):
+    async def longfunc(ctx):
+        await asyncio.sleep(3600)
+
+    async def wait_and_abort(job, delay=0.1):
+        await asyncio.sleep(delay)
+        await job.abort()
+
+    caplog.set_level(logging.INFO)
+    # try autodelete unknown job_ids
+    await arq_redis.set(f'{abort_key_prefix}todel', b'1')
+    job = await arq_redis.enqueue_job('longfunc', _job_id='testing')
+
+    worker: Worker = worker(functions=[func(longfunc, name='longfunc')], abort_jobs=True, poll_delay=0.1)
+    assert worker.jobs_complete == 0
+    assert worker.jobs_failed == 0
+    assert worker.jobs_retried == 0
+    await asyncio.gather(wait_and_abort(job), worker.main())
+    assert worker.jobs_complete == 0
+    assert worker.jobs_failed == 1
+    assert worker.jobs_retried == 0
+    log = re.sub(r'\d+.\d\ds', 'X.XXs', '\n'.join(r.message for r in caplog.records))
+    assert 'X.XXs → testing:longfunc()\n  X.XXs 🛇  testing:longfunc aborted' in log

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -732,7 +732,7 @@ async def test_abort_job(arq_redis: ArqRedis, worker, caplog, loop):
     await arq_redis.set(f'{abort_key_prefix}todel', b'1')
     job = await arq_redis.enqueue_job('longfunc', _job_id='testing')
 
-    worker: Worker = worker(functions=[func(longfunc, name='longfunc')], abort_jobs=True, poll_delay=0.1)
+    worker: Worker = worker(functions=[func(longfunc, name='longfunc')], allow_abort_jobs=True, poll_delay=0.1)
     assert worker.jobs_complete == 0
     assert worker.jobs_failed == 0
     assert worker.jobs_retried == 0

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11,7 +11,7 @@ import pytest
 from aioredis import create_redis_pool
 
 from arq.connections import ArqRedis
-from arq.constants import default_queue_name, health_check_key_suffix, job_key_prefix, abort_key_prefix
+from arq.constants import abort_key_prefix, default_queue_name, health_check_key_suffix, job_key_prefix
 from arq.jobs import Job, JobStatus
 from arq.worker import (
     FailedJobs,


### PR DESCRIPTION
Added method to cancel jobs through a new `abort()` function on Job. This allows long-running or deferred jobs to be cancelled.

This is a cleanup of PR #173 , since the submitter didn't finish the requested changes, with one design change: a `Worker` will cancel aborted jobs by default. I made the design change so that people aren't surprised when they call `abort()` on a `Job` and nothing happens. My guess is that it's more common to want to allow cancelling jobs than to block that operation.

This addresses issue #172 .