### PR TITLE
Fix Worker and Job to catch CancelledException.

### DIFF
--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -86,7 +86,7 @@ class Job:
                 result = info.result
                 if info.success:
                     return result
-                elif isinstance(result, Exception) or isinstance(result, asyncio.CancelledError):
+                elif isinstance(result, (Exception, asyncio.CancelledError)):
                     raise result
                 else:
                     raise SerializationError(result)

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -86,7 +86,7 @@ class Job:
                 result = info.result
                 if info.success:
                     return result
-                elif isinstance(result, Exception):
+                elif isinstance(result, Exception) or isinstance(result, asyncio.CancelledError):
                     raise result
                 else:
                     raise SerializationError(result)

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -459,14 +459,14 @@ class Worker:
             try:
                 async with async_timeout.timeout(timeout_s):
                     result = await function.coroutine(ctx, *args, **kwargs)
-            except Exception as e:
+            except (Exception, asyncio.CancelledError) as e:
                 exc_extra = getattr(e, 'extra', None)
                 if callable(exc_extra):
                     exc_extra = exc_extra()
                 raise
             else:
                 result_str = '' if result is None else truncate(repr(result))
-        except Exception as e:
+        except (Exception, asyncio.CancelledError) as e:
             finished_ms = timestamp_ms()
             t = (finished_ms - start_ms) / 1000
             if self.retry_jobs and isinstance(e, Retry):


### PR DESCRIPTION
As issue #190 noted, `except Exception as e` doesn't catch an `asyncio.CancelledError`. Some of the code in `Worker` clearly expects `asyncio.CancelledError` to be caught properly if raised in a `Job`. This PR fixes the appropriate lines to catch the error properly instead of kicking it all the way out to the enclosing Worker task, which then gets cancelled.