### PR TITLE
Fix to allow custom serializers

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -276,9 +276,9 @@ class Worker:
 
     async def main(self) -> None:
         if self._pool is None:
-            self._pool = await create_pool(self.redis_settings,
-                                           job_serializer=self.job_serializer,
-                                           job_deserializer=self.job_deserializer)
+            self._pool = await create_pool(
+                self.redis_settings, job_serializer=self.job_serializer, job_deserializer=self.job_deserializer
+            )
 
         logger.info('Starting worker for %d functions: %s', len(self.functions), ', '.join(self.functions))
         await log_redis_info(self.pool, logger.info)

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -276,7 +276,9 @@ class Worker:
 
     async def main(self) -> None:
         if self._pool is None:
-            self._pool = await create_pool(self.redis_settings)
+            self._pool = await create_pool(self.redis_settings,
+                                           job_serializer=self.job_serializer,
+                                           job_deserializer=self.job_deserializer)
 
         logger.info('Starting worker for %d functions: %s', len(self.functions), ', '.join(self.functions))
         await log_redis_info(self.pool, logger.info)


### PR DESCRIPTION
This fixes an issue where custom serializers are not used if the job is enqueued from the ctx within an existing task.