### PR TITLE
Let pool know about other worker's settings

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -276,7 +276,12 @@ class Worker:
 
     async def main(self) -> None:
         if self._pool is None:
-            self._pool = await create_pool(self.redis_settings)
+            self._pool = await create_pool(
+                self.redis_settings,
+                job_serializer=self.job_serializer,
+                job_deserializer=self.job_deserializer,
+                default_queue_name=self.queue_name,
+            )
 
         logger.info('Starting worker for %d functions: %s', len(self.functions), ', '.join(self.functions))
         await log_redis_info(self.pool, logger.info)


### PR DESCRIPTION
Allows `ArqRedis` instance, being a member of `Worker`, know about `default_queue_name` and serialization mechanism.

---

Fixes: #238