### PR TITLE
fix: arq is incompatible for aioredis>=2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         arq=arq.cli:cli
     """,
     install_requires=[
-        'aioredis>=1.1.0',
+        'aioredis>=1.1.0,<2.0.0',
         'click>=6.7',
         'pydantic>=1',
         'dataclasses>=0.6;python_version == "3.6"',


### PR DESCRIPTION
arq is currently breaking because, it now installs aioredis 2.0.0 and this version is not compatible as errors are now changed to exceptions and so on...