### PR TITLE
Update argument docstring definition

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -145,8 +145,8 @@ class Worker:
     :param keep_result: default duration to keep job results for
     :param keep_result_forever: whether to keep results forever
     :param poll_delay: duration between polling the queue for new jobs
-    :param queue_read_limit: the maximum number of jobs to pull from the queue each time it's polled; by default it
-                             equals ``max_jobs``
+    :param queue_read_limit: the maximum number of jobs to pull from the queue each time it's polled. By default it
+                             equals ``max_jobs`` * 5, or 100; whichever is higher.
     :param max_tries: default maximum number of times to retry a job
     :param health_check_interval: how often to set the health check key
     :param health_check_key: redis key under which health check is set


### PR DESCRIPTION
Looks like the `queue_read_limit` argument was described correctly when initially introduced in https://github.com/samuelcolvin/arq/pull/142, but that the default value was later changed to fix an issue (in https://github.com/samuelcolvin/arq/pull/180) without the docstring being updated.