### PR TITLE
Add link to WorkerSettings in documentation

### DIFF
--- a/docs/examples/main_demo.py
+++ b/docs/examples/main_demo.py
@@ -22,7 +22,8 @@ async def main():
         await redis.enqueue_job('download_content', url)
 
 # WorkerSettings defines the settings to use when creating the work,
-# it's used by the arq cli
+# it's used by the arq cli.
+# For a list of available settings, see https://arq-docs.helpmanual.io/#arq.worker.Worker
 class WorkerSettings:
     functions = [download_content]
     on_startup = startup


### PR DESCRIPTION
A minor detail I'd like to add to the docs. Obviously not necessary, but it took me longer than I'd like to admit to troubleshoot why the worker would not start (I had connection startup configured in my `startup` function instead) :smile: 