### PR TITLE
Add --custom-log-dict CLI option

### DIFF
--- a/arq/cli.py
+++ b/arq/cli.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib
 import logging.config
 import os
 import sys
@@ -19,6 +20,7 @@ burst_help = 'Batch mode: exit once no jobs are found in any queue.'
 health_check_help = 'Health Check: run a health check and exit.'
 watch_help = 'Watch a directory and reload the worker upon changes.'
 verbose_help = 'Enable verbose output.'
+logdict_help = "Import path for a dictionary in logdict form, to configure Arq's own logging."
 
 
 @click.command('arq')
@@ -28,7 +30,8 @@ verbose_help = 'Enable verbose output.'
 @click.option('--check', is_flag=True, help=health_check_help)
 @click.option('--watch', type=click.Path(exists=True, dir_okay=True, file_okay=False), help=watch_help)
 @click.option('-v', '--verbose', is_flag=True, help=verbose_help)
-def cli(*, worker_settings: str, burst: bool, check: bool, watch: str, verbose: bool) -> None:
+@click.option('--custom-log-dict', type=str, help=logdict_help)
+def cli(*, worker_settings: str, burst: bool, check: bool, watch: str, verbose: bool, custom_log_dict: str) -> None:
     """
     Job queues in python with asyncio and redis.
 
@@ -36,7 +39,15 @@ def cli(*, worker_settings: str, burst: bool, check: bool, watch: str, verbose: 
     """
     sys.path.append(os.getcwd())
     worker_settings_ = cast('WorkerSettingsType', import_string(worker_settings))
-    logging.config.dictConfig(default_log_config(verbose))
+    if custom_log_dict:
+        try:
+            config_path, config_dict = custom_log_dict.rsplit('.', maxsplit=1)
+            log_config = getattr(importlib.import_module(config_path), config_dict)
+        except (TypeError, AttributeError):
+            log_config = default_log_config(verbose)
+    else:
+        log_config = default_log_config(verbose)
+    logging.config.dictConfig(log_config)
 
     if check:
         exit(check_health(worker_settings_))

--- a/arq/cli.py
+++ b/arq/cli.py
@@ -1,5 +1,4 @@
 import asyncio
-import importlib
 import logging.config
 import os
 import sys
@@ -40,11 +39,7 @@ def cli(*, worker_settings: str, burst: bool, check: bool, watch: str, verbose: 
     sys.path.append(os.getcwd())
     worker_settings_ = cast('WorkerSettingsType', import_string(worker_settings))
     if custom_log_dict:
-        try:
-            config_path, config_dict = custom_log_dict.rsplit('.', maxsplit=1)
-            log_config = getattr(importlib.import_module(config_path), config_dict)
-        except (TypeError, AttributeError):
-            log_config = default_log_config(verbose)
+        log_config = import_string(custom_log_dict)
     else:
         log_config = default_log_config(verbose)
     logging.config.dictConfig(log_config)

--- a/tests/requirements-linting.txt
+++ b/tests/requirements-linting.txt
@@ -1,4 +1,4 @@
-black==21.12b0
+black==22.3.0
 flake8==4.0.1
 flake8-quotes==3.3.1
 isort[colors]==5.10.1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import pytest
 from click.testing import CliRunner
 
+from arq import logs
 from arq.cli import cli
 
 
@@ -46,3 +47,32 @@ def test_run_watch(mocker, cancel_remaining_task):
     result = runner.invoke(cli, ['tests.test_cli.WorkerSettings', '--watch', 'tests'])
     assert result.exit_code == 0
     assert '1 files changes, reloading arq worker...'
+
+
+custom_log_dict = {
+    'version': 1,
+    'handlers': {'custom': {'level': 'ERROR', 'class': 'logging.StreamHandler', 'formatter': 'custom'}},
+    'formatters': {'custom': {'format': '%(asctime)s: %(message)s', 'datefmt': '%H:%M:%S'}},
+    'loggers': {'arq': {'handlers': ['custom'], 'level': 'ERROR'}},
+}
+
+
+@pytest.mark.parametrize(
+    'cli_argument,log_dict_to_use',
+    [
+        (None, logs.default_log_config(verbose=False)),
+        ('--custom-log-dict=tests.test_cli.custom_log_dict', custom_log_dict),
+    ],
+)
+def test_custom_log_dict(mocker, loop, cli_argument, log_dict_to_use):
+    mocker.patch('asyncio.get_event_loop', lambda: loop)
+    mock_dictconfig = mocker.MagicMock()
+    mocker.patch('logging.config.dictConfig', mock_dictconfig)
+    arq_arguments = ['tests.test_cli.WorkerSettings']
+    if cli_argument is not None:
+        arq_arguments.append(cli_argument)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, arq_arguments)
+    assert result.exit_code == 0
+    mock_dictconfig.assert_called_with(log_dict_to_use)


### PR DESCRIPTION
This points at an import path for a dictionary (e.g. myproject.logging.CONFIG_DICT) that Arq can configure its logging with instead of using the default configuration.

This would be useful for e.g. configuring Arq logging output to use [python-json-logger](https://github.com/madzak/python-json-logger).

We use this in a fork of Arq for a project I'm working on, and I wanted to contribute this back upstream. I'm happy to make any changes that are needed.