### PR TITLE
Add the username option to RedisSettings

### DIFF
--- a/arq/connections.py
+++ b/arq/connections.py
@@ -42,6 +42,7 @@ class RedisSettings:
     host: Union[str, List[Tuple[str, int]]] = 'localhost'
     port: int = 6379
     database: int = 0
+    username: Optional[str] = None
     password: Optional[str] = None
     ssl: Union[bool, None, SSLContext] = None
     conn_timeout: int = 1
@@ -59,6 +60,7 @@ class RedisSettings:
             host=conf.hostname or 'localhost',
             port=conf.port or 6379,
             ssl=conf.scheme == 'rediss',
+            username=conf.username,
             password=conf.password,
             database=int((conf.path or '0').strip('/')),
         )
@@ -225,7 +227,9 @@ async def create_pool(
         )
 
     try:
-        pool = pool_factory(db=settings.database, password=settings.password, encoding='utf8')
+        pool = pool_factory(
+            db=settings.database, username=settings.username, password=settings.password, encoding='utf8'
+        )
         pool.job_serializer = job_serializer
         pool.job_deserializer = job_deserializer
         pool.default_queue_name = default_queue_name

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,7 +17,7 @@ def test_settings_changed():
     settings = RedisSettings(port=123)
     assert settings.port == 123
     assert (
-        "RedisSettings(host='localhost', port=123, database=0, password=None, ssl=None, conn_timeout=1, "
+        "RedisSettings(host='localhost', port=123, database=0, username=None, password=None, ssl=None, conn_timeout=1, "
         "conn_retries=5, conn_retry_delay=1, sentinel=False, sentinel_master='mymaster')"
     ) == str(settings)
 
@@ -106,7 +106,6 @@ def test_redis_settings_validation():
 
     s1 = Settings(redis_settings='redis://foobar:123/4')
     assert s1.redis_settings.host == 'foobar'
-    assert s1.redis_settings.host == 'foobar'
     assert s1.redis_settings.port == 123
     assert s1.redis_settings.database == 4
     assert s1.redis_settings.ssl is False
@@ -121,6 +120,11 @@ def test_redis_settings_validation():
     s3 = Settings(redis_settings={'ssl': True})
     assert s3.redis_settings.host == 'localhost'
     assert s3.redis_settings.ssl is True
+
+    s4 = Settings(redis_settings='redis://user:pass@foobar')
+    assert s4.redis_settings.host == 'foobar'
+    assert s4.redis_settings.username == 'user'
+    assert s4.redis_settings.password == 'pass'
 
 
 def test_ms_to_datetime_tz(env: SetEnv):


### PR DESCRIPTION
This PR adds the ability to pass the `username` option to the Redis connection