### PR TITLE
Support abort for deferred tasks

### DIFF
--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -156,13 +156,23 @@ class Job:
         :param poll_delay: how often to poll redis for the job result
         :return: True if the job aborted properly, False otherwise
         """
-        await self._redis.zadd(abort_jobs_ss, {self.job_id: timestamp_ms()})
-        try:
-            await self.result(timeout=timeout, poll_delay=poll_delay)
-        except asyncio.CancelledError:
-            return True
+        job_info = await self.info()
+        if job_info.score > timestamp_ms():
+            async with self._redis.pipeline(transaction=True) as tr:
+                tr.zrem(self._queue_name, self.job_id)
+                tr.zadd(self._queue_name, {self.job_id: 1})
+                tr.zadd(abort_jobs_ss, {self.job_id: timestamp_ms()})
+                await tr.execute()
+            raise asyncio.TimeoutError
+            
         else:
-            return False
+            await self._redis.zadd(abort_jobs_ss, {self.job_id: timestamp_ms()})
+            try:
+                await self.result(timeout=timeout, poll_delay=poll_delay)
+            except asyncio.CancelledError:
+                return True
+            else:
+                return False
 
     def __repr__(self) -> str:
         return f'<arq job {self.job_id}>'

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -69,7 +69,7 @@ class Job:
     def __init__(
         self,
         job_id: str,
-        redis: Redis[bytes],
+        redis: Redis,
         _queue_name: str = default_queue_name,
         _deserializer: Optional[Deserializer] = None,
     ):

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -69,7 +69,7 @@ class Job:
     def __init__(
         self,
         job_id: str,
-        redis: Redis,
+        redis: 'Redis[bytes]',
         _queue_name: str = default_queue_name,
         _deserializer: Optional[Deserializer] = None,
     ):

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -161,8 +161,9 @@ class Job:
             async with self._redis.pipeline(transaction=True) as tr:
                 tr.zrem(self._queue_name, self.job_id)  # type: ignore[unused-coroutine]
                 tr.zadd(self._queue_name, {self.job_id: 1})  # type: ignore[unused-coroutine]
-                tr.zadd(abort_jobs_ss, {self.job_id: timestamp_ms()})  # type: ignore[unused-coroutine]
                 await tr.execute()
+
+        await self._redis.zadd(abort_jobs_ss, {self.job_id: timestamp_ms()})
 
         try:
             await self.result(timeout=timeout, poll_delay=poll_delay)

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -69,7 +69,7 @@ class Job:
     def __init__(
         self,
         job_id: str,
-        redis: 'Redis[bytes]',
+        redis: Redis,
         _queue_name: str = default_queue_name,
         _deserializer: Optional[Deserializer] = None,
     ):
@@ -118,8 +118,7 @@ class Job:
             if v:
                 info = deserialize_job(v, deserializer=self._deserializer)
         if info:
-            s = await self._redis.zscore(self._queue_name, self.job_id)
-            info.score = None if s is None else int(s)
+            info.score = await self._redis.zscore(self._queue_name, self.job_id)
         return info
 
     async def result_info(self) -> Optional[JobResult]:
@@ -159,19 +158,17 @@ class Job:
         job_info = await self.info()
         if job_info and job_info.score and job_info.score > timestamp_ms():
             async with self._redis.pipeline(transaction=True) as tr:
-                tr.zrem(self._queue_name, self.job_id)
-                tr.zadd(self._queue_name, {self.job_id: 1})
-                tr.zadd(abort_jobs_ss, {self.job_id: timestamp_ms()})
+                tr.zrem(self._queue_name, self.job_id)  # type: ignore[unused-coroutine]
+                tr.zadd(self._queue_name, {self.job_id: 1})  # type: ignore[unused-coroutine]
+                tr.zadd(abort_jobs_ss, {self.job_id: timestamp_ms()}) # type: ignore[unused-coroutine]
                 await tr.execute()
 
+        try:
+            await self.result(timeout=timeout, poll_delay=poll_delay)
+        except asyncio.CancelledError:
+            return True
         else:
-            await self._redis.zadd(abort_jobs_ss, {self.job_id: timestamp_ms()})
-            try:
-                await self.result(timeout=timeout, poll_delay=poll_delay)
-            except asyncio.CancelledError:
-                return True
-            else:
-                return False
+            return False
 
     def __repr__(self) -> str:
         return f'<arq job {self.job_id}>'

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -163,7 +163,7 @@ class Job:
                 tr.zadd(self._queue_name, {self.job_id: 1})
                 tr.zadd(abort_jobs_ss, {self.job_id: timestamp_ms()})
                 await tr.execute()
-            raise asyncio.TimeoutError
+
         else:
             await self._redis.zadd(abort_jobs_ss, {self.job_id: timestamp_ms()})
             try:

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -164,7 +164,6 @@ class Job:
                 tr.zadd(abort_jobs_ss, {self.job_id: timestamp_ms()})
                 await tr.execute()
             raise asyncio.TimeoutError
-            
         else:
             await self._redis.zadd(abort_jobs_ss, {self.job_id: timestamp_ms()})
             try:

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -157,7 +157,7 @@ class Job:
         :return: True if the job aborted properly, False otherwise
         """
         job_info = await self.info()
-        if job_info.score > timestamp_ms():
+        if job_info and job_info.score and job_info.score > timestamp_ms():
             async with self._redis.pipeline(transaction=True) as tr:
                 tr.zrem(self._queue_name, self.job_id)
                 tr.zadd(self._queue_name, {self.job_id: 1})

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5,7 +5,6 @@ import re
 import signal
 import sys
 from unittest.mock import MagicMock
-from freezegun import freeze_time
 from datetime import datetime, timedelta
 
 import msgpack

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4,12 +4,12 @@ import logging
 import re
 import signal
 import sys
-from unittest.mock import MagicMock
-from freezegun import freeze_time
 from datetime import datetime
+from unittest.mock import MagicMock
 
 import msgpack
 import pytest
+from freezegun import freeze_time
 
 from arq.connections import ArqRedis, RedisSettings
 from arq.constants import abort_jobs_ss, default_queue_name, expires_extra_ms, health_check_key_suffix, job_key_prefix

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4,8 +4,8 @@ import logging
 import re
 import signal
 import sys
-from unittest.mock import MagicMock
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock
 
 import msgpack
 import pytest

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -4,8 +4,9 @@ import logging
 import re
 import signal
 import sys
-from datetime import datetime, timedelta
 from unittest.mock import MagicMock
+from freezegun import freeze_time
+from datetime import datetime, timedelta
 
 import msgpack
 import pytest
@@ -838,7 +839,8 @@ async def test_abort_deferred_job_before(arq_redis: ArqRedis, worker, caplog, lo
     assert worker.jobs_failed == 0
     assert worker.jobs_retried == 0
 
-    await job.abort(timeout=0)
+    with pytest.raises(asyncio.TimeoutError):
+        await job.abort(timeout=0)
     await worker.main()
 
     assert worker.jobs_complete == 0


### PR DESCRIPTION
There is an issue when aborting a deferred task. 

Currently when you abort a deferred task, the worker will wait until the deferred time is met to properly perform the delete.

This behaviour make it complicated to perform test that implicate canceling a deferred task.

I implemented a way to update the score of the deferred task when aborting it, but may be there is a better way to do this.
