### PR TITLE
Fix CI failures caused by click and black mismatch

### DIFF
--- a/tests/requirements-linting.txt
+++ b/tests/requirements-linting.txt
@@ -1,4 +1,4 @@
-black==21.12b0
+black==22.3.0
 flake8==4.0.1
 flake8-quotes==3.3.1
 isort[colors]==5.10.1


### PR DESCRIPTION
The change fixes:
  ImportError: cannot import name ‘_unicodefun’ from ‘click’