### PR TITLE
Fix: crash in case of not installed pytz

### DIFF
--- a/arq/utils.py
+++ b/arq/utils.py
@@ -35,7 +35,7 @@ def to_unix_ms(dt: datetime) -> int:
 
 
 @lru_cache()
-def get_tz() -> Optional[pytz.BaseTzInfo if pytz else None]:
+def get_tz() -> Optional["pytz.BaseTzInfo"]:
     if pytz:  # pragma: no branch
         for timezone_key in timezone_env_vars:
             tz_name = os.getenv(timezone_key)

--- a/arq/utils.py
+++ b/arq/utils.py
@@ -35,7 +35,7 @@ def to_unix_ms(dt: datetime) -> int:
 
 
 @lru_cache()
-def get_tz() -> Optional["pytz.BaseTzInfo"]:
+def get_tz() -> Optional['pytz.BaseTzInfo']:
     if pytz:  # pragma: no branch
         for timezone_key in timezone_env_vars:
             tz_name = os.getenv(timezone_key)

--- a/arq/utils.py
+++ b/arq/utils.py
@@ -35,7 +35,7 @@ def to_unix_ms(dt: datetime) -> int:
 
 
 @lru_cache()
-def get_tz() -> Optional[pytz.BaseTzInfo]:
+def get_tz() -> Optional[pytz.BaseTzInfo if pytz else None]:
     if pytz:  # pragma: no branch
         for timezone_key in timezone_env_vars:
             tz_name = os.getenv(timezone_key)


### PR DESCRIPTION
This small change fixes the crash In case of not installed `pytz`.

Here is example errors traceback:
`Traceback (most recent call last):
  File ".../main.py", line 14, in <module>
    import arq.cli
  File "....../venv/lib/python3.9/site-packages/arq/__init__.py", line 1, in <module>
    from .connections import ArqRedis, create_pool  # noqa F401
  File "....../venv/lib/python3.9/site-packages/arq/connections.py", line 18, in <module>
    from .jobs import Deserializer, Job, JobDef, JobResult, Serializer, deserialize_job, serialize_job
  File "....../venv/lib/python3.9/site-packages/arq/jobs.py", line 13, in <module>
    from .utils import ms_to_datetime, poll, timestamp_ms
  File "....../venv/lib/python3.9/site-packages/arq/utils.py", line 38, in <module>
    def get_tz() -> Optional[pytz.BaseTzInfo]:
AttributeError: 'NoneType' object has no attribute 'BaseTzInfo'`