### PR TITLE
Do not log job result

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -27,16 +27,7 @@ from .constants import (
     result_key_prefix,
     retry_key_prefix,
 )
-from .utils import (
-    args_to_string,
-    import_string,
-    ms_to_datetime,
-    poll,
-    timestamp_ms,
-    to_ms,
-    to_seconds,
-    to_unix_ms,
-)
+from .utils import args_to_string, import_string, ms_to_datetime, poll, timestamp_ms, to_ms, to_seconds, to_unix_ms
 
 if TYPE_CHECKING:
     from .typing import SecondsTimedelta, StartupShutdown, WorkerCoroutine, WorkerSettingsType  # noqa F401

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -36,7 +36,6 @@ from .utils import (
     to_ms,
     to_seconds,
     to_unix_ms,
-    truncate,
 )
 
 if TYPE_CHECKING:
@@ -552,8 +551,6 @@ class Worker:
                 if callable(exc_extra):
                     exc_extra = exc_extra()
                 raise
-            else:
-                result_str = '' if result is None else truncate(repr(result))
             finally:
                 del self.job_tasks[job_id]
 
@@ -585,7 +582,7 @@ class Worker:
         else:
             success = True
             finished_ms = timestamp_ms()
-            logger.info('%6.2fs ← %s ● %s', (finished_ms - start_ms) / 1000, ref, result_str)
+            logger.info('%6.2fs ← %s', (finished_ms - start_ms) / 1000, ref)
             finish = True
             self.jobs_complete += 1
 

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -102,7 +102,7 @@ async def test_job_successful(worker, caplog, arq_redis, poll_delay):
     assert worker.jobs_retried == 0
 
     log = re.sub(r'(\d+).\d\ds', r'\1.XXs', '\n'.join(r.message for r in caplog.records))
-    assert '  0.XXs → cron:foobar()\n  0.XXs ← cron:foobar ● 42' in log
+    assert '  0.XXs → cron:foobar()\n  0.XXs ← cron:foobar' in log
 
     # Assert the in-progress key still exists.
     keys = await arq_redis.keys(in_progress_key_prefix + '*')
@@ -121,7 +121,7 @@ async def test_job_successful_on_specific_queue(worker, caplog):
     assert worker.jobs_retried == 0
 
     log = re.sub(r'(\d+).\d\ds', r'\1.XXs', '\n'.join(r.message for r in caplog.records))
-    assert '  0.XXs → cron:foobar()\n  0.XXs ← cron:foobar ● 42' in log
+    assert '  0.XXs → cron:foobar()\n  0.XXs ← cron:foobar' in log
 
 
 async def test_not_run(worker, caplog):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -123,7 +123,7 @@ async def test_job_successful(arq_redis: ArqRedis, worker, caplog):
     assert worker.jobs_retried == 0
 
     log = re.sub(r'\d+.\d\ds', 'X.XXs', '\n'.join(r.message for r in caplog.records))
-    assert 'X.XXs → testing:foobar()\n  X.XXs ← testing:foobar ● 42' in log
+    assert 'X.XXs → testing:foobar()\n  X.XXs ← testing:foobar' in log
 
 
 async def test_job_retry(arq_redis: ArqRedis, worker, caplog):
@@ -142,7 +142,7 @@ async def test_job_retry(arq_redis: ArqRedis, worker, caplog):
     log = re.sub(r'(\d+).\d\ds', r'\1.XXs', '\n'.join(r.message for r in caplog.records))
     assert '0.XXs ↻ testing:retry retrying job in 0.XXs\n' in log
     assert '0.XXs → testing:retry() try=2\n' in log
-    assert '0.XXs ← testing:retry ●' in log
+    assert '0.XXs ← testing:retry' in log
 
 
 async def test_job_retry_dont_retry(arq_redis: ArqRedis, worker, caplog):
@@ -342,7 +342,7 @@ async def test_job_old(arq_redis: ArqRedis, worker, caplog):
     assert worker.jobs_retried == 0
 
     log = re.sub(r'(\d+).\d\ds', r'\1.XXs', '\n'.join(r.message for r in caplog.records))
-    assert log.endswith('  0.XXs → testing:foobar() delayed=2.XXs\n' '  0.XXs ← testing:foobar ● 42')
+    assert log.endswith('  0.XXs → testing:foobar() delayed=2.XXs\n' '  0.XXs ← testing:foobar')
 
 
 async def test_retry_repr():
@@ -749,7 +749,7 @@ async def test_non_burst(arq_redis: ArqRedis, worker, caplog, loop):
     assert worker.jobs_complete == 1
     assert worker.jobs_retried == 0
     assert worker.jobs_failed == 0
-    assert '← testing:foo ● 2' in caplog.text
+    assert '← testing:foo' in caplog.text
 
 
 async def test_multi_exec(arq_redis: ArqRedis, worker, caplog):
@@ -873,7 +873,7 @@ async def test_not_abort_job(arq_redis: ArqRedis, worker, caplog, loop):
     assert worker.jobs_failed == 0
     assert worker.jobs_retried == 0
     log = re.sub(r'\d+.\d\ds', 'X.XXs', '\n'.join(r.message for r in caplog.records))
-    assert 'X.XXs → testing:shortfunc()\n  X.XXs ← testing:shortfunc ●' in log
+    assert 'X.XXs → testing:shortfunc()\n  X.XXs ← testing:shortfunc' in log
     await worker.main()
     assert worker.aborting_tasks == set()
     assert worker.tasks == {}


### PR DESCRIPTION
It is not always desirable to include job result in logs.

This PR is one of the possible solutions to #349, where job result is simply removed from the logs.
An alternative would be to make the behavior configurable.
