### PR TITLE
Allow to opt-out from logging results

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -170,6 +170,8 @@ class Worker:
     :param job_deserializer: a function that deserializes bytes into Python objects, defaults to pickle.loads
     :param expires_extra_ms: the default length of time from when a job is expected to start
      after which the job expires, defaults to 1 day in ms.
+    :param log_results: when set to true (default) results for successful jobs
+      will be logged
     """
 
     def __init__(

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -267,6 +267,7 @@ class Worker:
         self.job_serializer = job_serializer
         self.job_deserializer = job_deserializer
         self.expires_extra_ms = expires_extra_ms
+        self.log_results = log_results
 
     def run(self) -> None:
         """
@@ -554,7 +555,7 @@ class Worker:
                     exc_extra = exc_extra()
                 raise
             else:
-                result_str = '' if result is None else truncate(repr(result))
+                result_str = '' if result is None or not self.log_results else truncate(repr(result))
             finally:
                 del self.job_tasks[job_id]
 

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -202,6 +202,7 @@ class Worker:
         job_serializer: Optional[Serializer] = None,
         job_deserializer: Optional[Deserializer] = None,
         expires_extra_ms: int = expires_extra_ms,
+        log_results: bool = True,
     ):
         self.functions: Dict[str, Union[Function, CronJob]] = {f.name: f for f in map(func, functions)}
         if queue_name is None:


### PR DESCRIPTION
It is not always desirable to include job result in logs.

This PR is one of the possible solutions to #349, where logging results can be suppressed by setting the new `Worker.log_results` flag to false.