### PR TITLE
Add timezone support for cron jobs

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -679,7 +679,7 @@ class Worker:
             await tr.execute()
 
     async def heart_beat(self) -> None:
-        now = datetime.now()
+        now = datetime.now(tz=self.timezone)
         await self.record_health()
 
         cron_window_size = max(self.poll_delay_s, 0.5)  # Clamp the cron delay to 0.5

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 import signal
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import partial
 from signal import Signals
 from time import time
@@ -170,6 +170,8 @@ class Worker:
     :param job_deserializer: a function that deserializes bytes into Python objects, defaults to pickle.loads
     :param expires_extra_ms: the default length of time from when a job is expected to start
      after which the job expires, defaults to 1 day in ms.
+    :param timezone: timezone used for evaluation of cron schedules,
+        defaults to system timezone
     """
 
     def __init__(
@@ -202,6 +204,7 @@ class Worker:
         job_serializer: Optional[Serializer] = None,
         job_deserializer: Optional[Deserializer] = None,
         expires_extra_ms: int = expires_extra_ms,
+        timezone: Optional[timezone] = None,
     ):
         self.functions: Dict[str, Union[Function, CronJob]] = {f.name: f for f in map(func, functions)}
         if queue_name is None:
@@ -266,6 +269,9 @@ class Worker:
         self.job_serializer = job_serializer
         self.job_deserializer = job_deserializer
         self.expires_extra_ms = expires_extra_ms
+
+        # default to system timezone
+        self.timezone = datetime.now().astimezone().tzinfo if timezone is None else timezone
 
     def run(self) -> None:
         """

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -51,6 +51,12 @@ def test_next_cron(previous, expected, kwargs):
     print(f'{diff.total_seconds() * 1000:0.3f}ms')
 
 
+def test_next_cron_preserves_tzinfo():
+    previous = datetime.fromisoformat('2016-06-01T12:10:10+02:00')
+    assert previous.tzinfo is not None
+    assert next_cron(previous, second=20).tzinfo is previous.tzinfo
+
+
 def test_next_cron_invalid():
     with pytest.raises(ValueError):
         next_cron(datetime(2001, 1, 1, 0, 0, 0), weekday='monday')

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -123,7 +123,7 @@ async def test_calculate_next_is_called_with_aware_datetime(worker, mocker: Mock
 
     await worker.main()
 
-    assert spy_run_cron.call_args.args[0].tzinfo is not None
+    assert spy_run_cron.call_args[0][0].tzinfo is not None
     assert worker.cron_jobs[0].next_run.tzinfo is not None
 
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -929,3 +929,9 @@ async def test_on_job(arq_redis: ArqRedis, worker):
     assert worker.jobs_failed == 0
     assert worker.jobs_retried == 0
     assert result['called'] == 2
+
+
+async def test_worker_timezone_defaults_to_system_timezone(worker):
+    worker = worker(functions=[func(foobar)])
+    assert worker.timezone is not None
+    assert worker.timezone == datetime.now().astimezone().tzinfo


### PR DESCRIPTION
This changeset ensures that calculations of execution time for cron jobs are done on timezone-aware datetime objects. Timezone can be specified by a new `Worker` attribute `timezone` which defaults to the system timezone (which preserves the current behavior).

Fixes: #351