### PR TITLE
Prevent worker getting stuck in terminating state

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -382,14 +382,14 @@ class Worker:
 
             await self.start_jobs(job_ids)
 
-            if self.allow_abort_jobs:
-                await self._cancel_aborted_jobs()
+        if self.allow_abort_jobs:
+            await self._cancel_aborted_jobs()
 
-            for job_id, t in list(self.tasks.items()):
-                if t.done():
-                    del self.tasks[job_id]
-                    # required to make sure errors in run_job get propagated
-                    t.result()
+        for job_id, t in list(self.tasks.items()):
+            if t.done():
+                del self.tasks[job_id]
+                # required to make sure errors in run_job get propagated
+                t.result()
 
         await self.heart_beat()
 


### PR DESCRIPTION
First commit proves the bug (see the pipeline failures [here](https://github.com/samuelcolvin/arq/actions/runs/3628698559))  
Second commit contains the fix. 

Closes #369 