### PR TITLE
Allow infinite retry

### DIFF
--- a/arq/connections.py
+++ b/arq/connections.py
@@ -266,7 +266,7 @@ async def create_pool(
         except (ConnectionError, OSError, RedisError, asyncio.TimeoutError) as e:
             if retry < settings.conn_retries:
                 logger.warning(
-                    'redis connection error %s:%s %s %s, %d retries remaining...',
+                    'redis connection error %s:%s %s %s, %s retries remaining...',
                     settings.host,
                     settings.port,
                     e.__class__.__name__,


### PR DESCRIPTION
In some contexts (cluster) it is useful to allow infinite retries `float('inf')`. Especially in clusters redis might be not available for some time but we don't want the worker to crash on that. Instead it just should wait until redis comes available again.

`float('inf')` always compare greater than any float or int. So it should be safe to use. But `str(float('inf'))` translates to `'inf'` and that's why this change is necessary. 