### PR TITLE
Improves after_job_end hook

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -624,6 +624,7 @@ class Worker:
         )
         result_timeout_s = self.keep_result_s if function.keep_result_s is None else function.keep_result_s
         result_data = None
+        job_result = None
         if result is not no_result and (keep_result_forever or result_timeout_s > 0):
             job_result, result_data = _create_result(
                 function_name,
@@ -687,9 +688,10 @@ class Worker:
                 tr.delete(*delete_keys)  # type: ignore[unused-coroutine]
             await tr.execute()
 
-    async def _after_job_end(self, ctx: Dict[Any, Any], job_result: JobResult) -> None:
+    async def _after_job_end(self, ctx: Dict[Any, Any], job_result: Optional[JobResult]) -> None:
         if self.after_job_end:
-            ctx['job_result'] = job_result
+            if job_result:
+                ctx['job_result'] = job_result
             await self.after_job_end(ctx)
 
     async def finish_failed_job(self, job_id: str, result_data: Optional[bytes]) -> None:

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -545,7 +545,6 @@ class Worker:
         if job_try > max_tries:
             t = (timestamp_ms() - enqueue_time_ms) / 1000
             logger.warning('%6.2fs ! %s max retries %d exceeded', t, ref, max_tries)
-            self.jobs_failed += 1
             return await job_failed(JobExecutionFailed(f'max {max_tries} retries exceeded'), ref=ref)
 
         result = no_result

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -959,6 +959,7 @@ async def test_on_job(arq_redis: ArqRedis, worker):
 
     async def after_end(ctx):
         assert ctx['job_id'] == 'testing'
+        assert ctx['job_result'].success
         result['called'] += 2
 
     async def test(ctx):


### PR DESCRIPTION
Since `finish_job` can fail, I adjusted the `after_job_end` hook to always receive a copy of the the `JobResult` that would get written into redis.

I also updated all of the other places that recorded a failing job to call `after_job_end` as well and added a `asyncio.shield` to `after_job_end` as it is a great way to do something with the job result (like generate metrics for New Relic/Prometheus/etc.).