### PR TITLE
Fix "retry_on_error" type annotation

### DIFF
--- a/arq/connections.py
+++ b/arq/connections.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from operator import attrgetter
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Type, Union, cast
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
@@ -50,7 +50,7 @@ class RedisSettings:
     sentinel_master: str = 'mymaster'
 
     retry_on_timeout: bool = False
-    retry_on_error: Optional[List[Exception]] = None
+    retry_on_error: Optional[List[Type[Exception]]] = None
     retry: Optional[Retry] = None
 
     @classmethod


### PR DESCRIPTION
When a list of classes (not instances) is assigned to `RedisSettings.retry_on_error`, mypy finds an error:
```
$ make mypy
mypy arq
arq/poc_annotations.py:5: error: List item 0 has incompatible type "type[ConnectionError]"; expected "Exception"  [list-item]
Found 1 error in 1 file (checked 13 source files)
make: *** [Makefile:46: mypy] Error 1
```
Redis library for the similar parameter has the type annotation `Optional[List[Type[Exception]]]` ([source](https://github.com/redis/redis-py/blob/07fc339b4a4088c1ff052527685ebdde43dfc4be/redis/asyncio/cluster.py#L266))

How to reproduce:
create a file `arq/poc_annotations.py`

```python
from arq.connections import RedisSettings
from redis.exceptions import ConnectionError


settings = RedisSettings(retry_on_error=[ConnectionError])
```



