### PR TITLE
Set the result after cleaning the queue to reduce stuck transaction

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -691,12 +691,12 @@ class Worker:
                 tr.pexpire(in_progress_key, to_ms(keep_in_progress))
 
             if finish:
-                if result_data:
-                    expire = None if keep_result_forever else result_timeout_s
-                    tr.set(result_key_prefix + job_id, result_data, px=to_ms(expire))
                 delete_keys += [retry_key_prefix + job_id, job_key_prefix + job_id]
                 tr.zrem(abort_jobs_ss, job_id)
                 tr.zrem(self.queue_name, job_id)
+                if result_data:
+                    expire = None if keep_result_forever else result_timeout_s
+                    tr.set(result_key_prefix + job_id, result_data, px=to_ms(expire))
             elif incr_score:
                 tr.zincrby(self.queue_name, incr_score, job_id)
             if delete_keys:


### PR DESCRIPTION
We are seeing spikes of `ResultNotFound` error from time to time. We are unable to reproduce reliably, but we think it might be coming from ARQ/Redis. Our asyncio tasks are not blocked and not every job get `ResultNotFound` during the spikes.

So my current theory is that we have lock contention in Redis in the `finish_job` function. It could be possible that deleting the `job_id` from the queue is blocked for more than the result TTL (Which we have at 10s) then by the time the pipeline execute, the result key with already be expired.

This change simply move the result key set after we delete the `job_id` from the busy queue that might block on a lock. If my theory is right, we should stop seeing the `ResultNotFound` error.