### PR TITLE
Add Redis Streams option for job delivery

### DIFF
--- a/arq/cli.py
+++ b/arq/cli.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from .typing import WorkerSettingsType
 
 burst_help = 'Batch mode: exit once no jobs are found in any queue.'
+stream_help = 'Stream mode: use redis streams for job delivery. Does not support batch mode.'
 health_check_help = 'Health Check: run a health check and exit.'
 watch_help = 'Watch a directory and reload the worker upon changes.'
 verbose_help = 'Enable verbose output.'
@@ -26,11 +27,14 @@ logdict_help = "Import path for a dictionary in logdict form, to configure Arq's
 @click.version_option(VERSION, '-V', '--version', prog_name='arq')
 @click.argument('worker-settings', type=str, required=True)
 @click.option('--burst/--no-burst', default=None, help=burst_help)
+@click.option('--stream/--no-stream', default=None, help=stream_help)
 @click.option('--check', is_flag=True, help=health_check_help)
 @click.option('--watch', type=click.Path(exists=True, dir_okay=True, file_okay=False), help=watch_help)
 @click.option('-v', '--verbose', is_flag=True, help=verbose_help)
 @click.option('--custom-log-dict', type=str, help=logdict_help)
-def cli(*, worker_settings: str, burst: bool, check: bool, watch: str, verbose: bool, custom_log_dict: str) -> None:
+def cli(
+    *, worker_settings: str, burst: bool, stream: bool, check: bool, watch: str, verbose: bool, custom_log_dict: str
+) -> None:
     """
     Job queues in python with asyncio and redis.
 
@@ -48,6 +52,8 @@ def cli(*, worker_settings: str, burst: bool, check: bool, watch: str, verbose: 
         exit(check_health(worker_settings_))
     else:
         kwargs = {} if burst is None else {'burst': burst}
+        if stream:
+            kwargs['stream'] = stream
         if watch:
             asyncio.run(watch_reload(watch, worker_settings_))
         else:

--- a/arq/constants.py
+++ b/arq/constants.py
@@ -1,4 +1,7 @@
 default_queue_name = 'arq:queue'
+default_worker_name = 'arq:worker'
+default_worker_group = 'arq:workers'
+stream_prefix = 'arq:stream:'
 job_key_prefix = 'arq:job:'
 in_progress_key_prefix = 'arq:in-progress:'
 result_key_prefix = 'arq:result:'


### PR DESCRIPTION
This pull request adds a basic implementation of Redis Streams, in order to avoid polling for new jobs in the worker and reduce latency, in accordance with objective 4 of issue #437. 

To create a worker that listens to a Redis Stream, we can use the cli or specify it in the code directly.

**CLI:**
`arq worker.WorkerSettings --stream`

**Code:**
```python
class WorkerSettings:
    functions = [...]
    stream = True
    ...
```

On the client, they must specify that they want to deliver a job to a worker through a Redis Stream.
```python
redis = await create_pool(RedisSettings())
await redis.enqueue_job('hello_world', _use_stream=True)
```

Here are the results of a _very_ simple benchmark that showcases the potential of using Redis Streams for improved latency.

**Polling:**
<img width="463" alt="Captura de pantalla 2024-05-04 a la(s) 8 12 28 a m" src="https://github.com/samuelcolvin/arq/assets/115488250/e96cccc4-3bdf-45ee-84ec-87c193f50d8a">
Average time: 0.268s

**Streaming:**
<img width="463" alt="Captura de pantalla 2024-05-04 a la(s) 8 15 34 a m" src="https://github.com/samuelcolvin/arq/assets/115488250/c5b6fb73-a44e-48d6-9ac3-f7789e6e2ff5">
Average time: 0.012s
