### PR TITLE
Stringify arguments and results only when logging is enabled

### DIFF
--- a/arq/utils.py
+++ b/arq/utils.py
@@ -4,7 +4,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 from time import time
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, Optional, Sequence, overload
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Dict, Optional, Sequence, overload
 
 from .constants import timezone_env_vars
 
@@ -17,6 +17,14 @@ logger = logging.getLogger('arq.utils')
 
 if TYPE_CHECKING:
     from .typing import SecondsTimedelta
+
+
+class LazyStr:
+    def __init__(self, fn: Callable[[], str]) -> None:
+        self.fn = fn
+
+    def __str__(self) -> str:
+        return self.fn()
 
 
 def as_int(f: float) -> int:

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -29,6 +29,7 @@ from .constants import (
     retry_key_prefix,
 )
 from .utils import (
+    LazyStr,
     args_to_string,
     import_string,
     ms_to_datetime,
@@ -580,7 +581,7 @@ class Worker:
         start_ms = timestamp_ms()
         success = False
         try:
-            s = args_to_string(args, kwargs)
+            s = LazyStr(partial(args_to_string, args, kwargs))
             extra = f' try={job_try}' if job_try > 1 else ''
             if (start_ms - score) > 1200:
                 extra += f' delayed={(start_ms - score) / 1000:0.2f}s'
@@ -596,7 +597,7 @@ class Worker:
                     exc_extra = exc_extra()
                 raise
             else:
-                result_str = '' if result is None or not self.log_results else truncate(repr(result))
+                result_str = LazyStr(lambda: '' if result is None or not self.log_results else truncate(repr(result)))
             finally:
                 del self.job_tasks[job_id]
 


### PR DESCRIPTION
One of our profiling profile shows that 40% of computing time is spent in `repr` call from ARQ. At the moment, even without logging this get called, which can be expensive on large inputs.