### PR TITLE
Allow `connection_pool` to be set in RedisSettings

### DIFF
--- a/arq/connections.py
+++ b/arq/connections.py
@@ -28,6 +28,7 @@ class RedisSettings:
     Used by :func:`arq.connections.create_pool` and :class:`arq.worker.Worker`.
     """
 
+    connection_pool: Optional[ConnectionPool] = None
     host: Union[str, List[Tuple[str, int]]] = 'localhost'
     port: int = 6379
     unix_socket_path: Optional[str] = None
@@ -251,6 +252,7 @@ async def create_pool(
     else:
         pool_factory = functools.partial(
             ArqRedis,
+            pool_or_conn=settings.connection_pool,
             host=settings.host,
             port=settings.port,
             unix_socket_path=settings.unix_socket_path,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,7 +19,7 @@ def test_settings_changed():
     settings = RedisSettings(port=123)
     assert settings.port == 123
     assert (
-        "RedisSettings(host='localhost', port=123, unix_socket_path=None, database=0, username=None, password=None, "
+        "RedisSettings(connection_pool=None, host='localhost', port=123, unix_socket_path=None, database=0, username=None, password=None, "
         "ssl=False, ssl_keyfile=None, ssl_certfile=None, ssl_cert_reqs='required', ssl_ca_certs=None, "
         'ssl_ca_data=None, ssl_check_hostname=False, conn_timeout=1, conn_retries=5, conn_retry_delay=1, '
         "max_connections=None, sentinel=False, sentinel_master='mymaster', "
@@ -203,6 +203,7 @@ def test_import_string_invalid_missing():
 def test_settings_plain():
     settings = RedisSettings()
     assert asdict(settings) == {
+        'connection_pool': None,
         'host': 'localhost',
         'port': 6379,
         'unix_socket_path': None,
@@ -232,6 +233,7 @@ def test_settings_from_socket_dsn():
     settings = RedisSettings.from_dsn('unix:///run/redis/redis.sock')
     # insert_assert(asdict(settings))
     assert asdict(settings) == {
+        'connection_pool': None,
         'host': 'localhost',
         'port': 6379,
         'unix_socket_path': '/run/redis/redis.sock',


### PR DESCRIPTION
@samuelcolvin @chrisguidry 
Thank you for a great library! 
It would be really grateful if this PR could be reviewed or a workaround for this issue provided.
Many thanks.

--------------------
We are using arq for our production app, and it appears that connection pool throws an error and `arq worker` crashes if the connection limit(`max_connections`) is reached. 
Not only does worker but the `enqueue_job` method also throws an error under the same condition.

This seems to be caused by the default `ConnectionPool` of redis-py.  
https://github.com/redis/redis-py/issues/2517

Code to reproduce:
```py
import asyncio
from arq import ArqRedis, create_pool
from arq.connections import RedisSettings

REDIS_SETTINGS = RedisSettings(
    max_connections=1
)

async def foo(ctx) -> None:
    print('ok')

async def main() -> None:
    redis: ArqRedis = await create_pool(REDIS_SETTINGS)
    for _ in range(2):
        await redis.enqueue_job('foo')

class Worker:
    functions = [foo]
    redis_settings = REDIS_SETTINGS

if __name__ == '__main__':
    asyncio.run(main())
```

By allowing `connection_pool ` to be set in RedisSettings, it seems to work as expected.
```py
import asyncio
from arq import ArqRedis, create_pool
from arq.connections import RedisSettings
from redis.asyncio import BlockingConnectionPool

REDIS_SETTINGS = RedisSettings(
    connection_pool=BlockingConnectionPool(max_connections=1)
)

async def foo(ctx) -> None:
    print("ok")

async def main() -> None:
    redis: ArqRedis = await create_pool(REDIS_SETTINGS)
    for _ in range(10):
        await redis.enqueue_job("foo")

class Worker:
    functions = [foo]
    redis_settings = REDIS_SETTINGS

if __name__ == "__main__":
    asyncio.run(main())
```

It appears that `Worker` can take `redis_pool` as an argument, but I guess we can handle this case more concisely this way for both `Worker` and `Enqueuer`, provided it does not break anything else. 