### PR TITLE
Allow SSL support for Sentinel

### DIFF
--- a/arq/connections.py
+++ b/arq/connections.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from operator import attrgetter
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union, cast
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
@@ -48,6 +48,7 @@ class RedisSettings:
 
     sentinel: bool = False
     sentinel_master: str = 'mymaster'
+    sentinel_kwargs: Optional[Dict[str, Any]] = None
 
     retry_on_timeout: bool = False
     retry_on_error: Optional[List[Exception]] = None
@@ -242,7 +243,7 @@ async def create_pool(
             client = Sentinel(  # type: ignore[misc]
                 *args,
                 sentinels=settings.host,
-                ssl=settings.ssl,
+                sentinel_kwargs=settings.sentinel_kwargs,
                 **kwargs,
             )
             redis = client.master_for(settings.sentinel_master, redis_class=ArqRedis)
@@ -255,13 +256,6 @@ async def create_pool(
             port=settings.port,
             unix_socket_path=settings.unix_socket_path,
             socket_connect_timeout=settings.conn_timeout,
-            ssl=settings.ssl,
-            ssl_keyfile=settings.ssl_keyfile,
-            ssl_certfile=settings.ssl_certfile,
-            ssl_cert_reqs=settings.ssl_cert_reqs,
-            ssl_ca_certs=settings.ssl_ca_certs,
-            ssl_ca_data=settings.ssl_ca_data,
-            ssl_check_hostname=settings.ssl_check_hostname,
             retry=settings.retry,
             retry_on_timeout=settings.retry_on_timeout,
             retry_on_error=settings.retry_on_error,
@@ -271,7 +265,17 @@ async def create_pool(
     while True:
         try:
             pool = pool_factory(
-                db=settings.database, username=settings.username, password=settings.password, encoding='utf8'
+                db=settings.database,
+                username=settings.username,
+                password=settings.password,
+                encoding='utf8',
+                ssl=settings.ssl,
+                ssl_keyfile=settings.ssl_keyfile,
+                ssl_certfile=settings.ssl_certfile,
+                ssl_cert_reqs=settings.ssl_cert_reqs,
+                ssl_ca_certs=settings.ssl_ca_certs,
+                ssl_ca_data=settings.ssl_ca_data,
+                ssl_check_hostname=settings.ssl_check_hostname,
             )
             pool.job_serializer = job_serializer
             pool.job_deserializer = job_deserializer

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,7 @@ def test_settings_changed():
         "RedisSettings(host='localhost', port=123, unix_socket_path=None, database=0, username=None, password=None, "
         "ssl=False, ssl_keyfile=None, ssl_certfile=None, ssl_cert_reqs='required', ssl_ca_certs=None, "
         'ssl_ca_data=None, ssl_check_hostname=False, conn_timeout=1, conn_retries=5, conn_retry_delay=1, '
-        "max_connections=None, sentinel=False, sentinel_master='mymaster', "
+        "max_connections=None, sentinel=False, sentinel_master='mymaster', sentinel_kwargs=None, "
         'retry_on_timeout=False, retry_on_error=None, retry=None)'
     ) == str(settings)
 
@@ -220,6 +220,7 @@ def test_settings_plain():
         'conn_retries': 5,
         'conn_retry_delay': 1,
         'sentinel': False,
+        'sentinel_kwargs': None,
         'sentinel_master': 'mymaster',
         'retry_on_timeout': False,
         'retry_on_error': None,
@@ -249,6 +250,7 @@ def test_settings_from_socket_dsn():
         'conn_retries': 5,
         'conn_retry_delay': 1,
         'sentinel': False,
+        'sentinel_kwargs': None,
         'sentinel_master': 'mymaster',
         'retry_on_timeout': False,
         'retry_on_error': None,


### PR DESCRIPTION
Currently there is no possibility to pass SSL parameters to connect to Sentinel instance and then to connect to the selected Node.

How it will work:

```py
import arq

settings = arq.connections.RedisSettings(
    host=[('localhost', 26379)],  # sentinel host/port
    port=6379,  # node port
    database=1,
    username='redis',  # node user
    password='***',  # node password
    ssl_keyfile='/ssl/client.key',
    ssl_certfile='/ssl/client.crt',
    ssl_ca_certs='/ssl/ca.crt',
    ssl=True,
    sentinel=True,
    sentinel_kwargs=dict(
        username='sentinel',  # sentinel user
        password='***',  # sentinel password
        ssl_keyfile='/ssl/client.key',
        ssl_certfile='/ssl/client.crt',
        ssl_ca_certs='/ssl/ca.crt',
        ssl=True,
    )
)   
pool = await arq.create_pool(settings)
```