### PR TITLE
Fix wrong reference in `Retry` docstring

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -95,7 +95,7 @@ def func(
 
 class Retry(RuntimeError):
     """
-    Special exception to retry the job (if ``max_retries`` hasn't been reached).
+    Special exception to retry the job (if ``max_tries`` hasn't been reached).
 
     :param defer: duration to wait before rerunning the job
     """


### PR DESCRIPTION
This change fixes a documentation issue that pushed me down a rabbit hole the other day.
The documentation for the `Retry` exception mentions the `max_retries` configuration parameter, but that parameter does not exist. The actual name of the relevant parameter is `max_tries` instead.