### PR TITLE
Add python3.14 version support

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import inspect
 import logging
+import sys
 import signal
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -266,7 +267,7 @@ class Worker:
         # self.job_tasks holds references the actual jobs running
         self.job_tasks: Dict[str, asyncio.Task[Any]] = {}
         self.main_task: Optional[asyncio.Task[None]] = None
-        self.loop = asyncio.get_event_loop()
+        self.loop = asyncio.get_event_loop() if sys.version_info < (3, 14) else asyncio.new_event_loop()
         self.ctx = ctx or {}
         max_timeout = max(f.timeout_s or self.job_timeout_s for f in self.functions.values())
         self.in_progress_timeout_s = (max_timeout or 0) + 10

--- a/requirements/linting.txt
+++ b/requirements/linting.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file=requirements/linting.txt --strip-extras requirements/linting.in
 #
-cffi==1.16.0
+cffi==2.0.0
     # via cryptography
 cryptography==42.0.5
     # via
     #   types-pyopenssl
     #   types-redis
-mypy==1.9.0
+mypy==1.18.2
     # via -r requirements/linting.in
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via mypy
 pycparser==2.22
     # via cffi
@@ -24,5 +24,5 @@ types-pytz==2024.1.0.20240203
     # via -r requirements/linting.in
 types-redis==4.6.0.20240311
     # via -r requirements/linting.in
-typing-extensions==4.10.0
+typing-extensions==4.15.0
     # via mypy

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -36,9 +36,9 @@ packaging==24.0
     #   pytest
 pluggy==1.4.0
     # via pytest
-pydantic==2.6.4
+pydantic==2.12.1
     # via -r requirements/testing.in
-pydantic-core==2.16.3
+pydantic-core==2.41.3
     # via pydantic
 pygments==2.17.2
     # via rich
@@ -71,7 +71,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-typing-extensions==4.10.0
+typing-extensions==4.15.0
     # via
     #   pydantic
     #   pydantic-core


### PR DESCRIPTION
This PR handles the following [asyncio behavioral changes](https://docs.python.org/3.14/whatsnew/3.14.html#id11) introduced in python3.14:

[asyncio.get_event_loop()](https://docs.python.org/3.14/library/asyncio-eventloop.html#asyncio.get_event_loop) now raises a RuntimeError if there is no current event loop, and no longer implicitly creates an event loop.

To support 3.14, this PR:
1. Fixes [Python] RuntimeError: no running event loop by checking version of python and use asyncio.new_event_loop()
2. Update dependencies versions for no conflicts with 3.14