### PR TITLE
Allow WorkerSettings inheritance

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -881,8 +881,12 @@ class Worker:
 
 def get_kwargs(settings_cls: 'WorkerSettingsType') -> Dict[str, NameError]:
     worker_args = set(inspect.signature(Worker).parameters.keys())
-    d = settings_cls if isinstance(settings_cls, dict) else settings_cls.__dict__
-    return {k: v for k, v in d.items() if k in worker_args}
+    if isinstance(settings_cls, dict):
+        return {k: v for k, v in settings_cls.items() if k in worker_args}
+    else:
+        return {
+            k: getattr(settings_cls, k) for k in dir(settings_cls) if k in worker_args
+        }
 
 
 def create_worker(settings_cls: 'WorkerSettingsType', **kwargs: Any) -> Worker:


### PR DESCRIPTION
Read Worker class attibutes (settings) from partent classes.
This way one may write base worker to settings as:
```
class BaseSettings:
    on_startup = startup
    on_shutdown = shutdown

class WorkerSettings(BaseSettings):
    functions = [download_content]
```
and allow multiple workers to reuse base settings.