### PR TITLE
feat: add debounce support to enqueue_job

### DIFF
--- a/arq/connections.py
+++ b/arq/connections.py
@@ -167,29 +167,29 @@ class ArqRedis(BaseRedis):
             job_exists = await pipe.exists(job_key)
             result_exists = await pipe.exists(result_key_prefix + job_id)
             in_progress = await pipe.exists(in_progress_key_prefix + job_id) if _debounce else False
+            can_debounce = _debounce and job_exists and not result_exists and not in_progress
 
-            if (job_exists or result_exists) and not (
-                _debounce and job_exists and not result_exists and not in_progress
-            ):
+            if (job_exists or result_exists) and not can_debounce:
                 await pipe.reset()
                 return None
 
-            if _debounce and job_exists:
+            now_ms = timestamp_ms()
+            if can_debounce:
                 existing_job_data = await pipe.get(job_key)
                 _, _, _, _, enqueue_time_ms = deserialize_job_raw(existing_job_data, deserializer=self.job_deserializer)
-                if debounce_max_ms is not None and timestamp_ms() - enqueue_time_ms >= debounce_max_ms:
+                if debounce_max_ms is not None and now_ms - enqueue_time_ms >= debounce_max_ms:
                     await pipe.reset()
                     return None
             else:
-                enqueue_time_ms = timestamp_ms()
+                enqueue_time_ms = now_ms
             if _defer_until is not None:
                 score = to_unix_ms(_defer_until)
             elif defer_by_ms:
-                score = enqueue_time_ms + defer_by_ms
+                score = now_ms + defer_by_ms
             else:
-                score = enqueue_time_ms
+                score = now_ms
 
-            expires_ms = expires_ms or score - enqueue_time_ms + self.expires_extra_ms
+            expires_ms = expires_ms or score - now_ms + self.expires_extra_ms
 
             job = serialize_job(function, args, kwargs, _job_try, enqueue_time_ms, serializer=self.job_serializer)
             pipe.multi()

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -14,7 +14,7 @@ from redis.asyncio.sentinel import Sentinel
 from redis.exceptions import RedisError, WatchError
 
 from .constants import default_queue_name, expires_extra_ms, job_key_prefix, result_key_prefix
-from .jobs import Deserializer, Job, JobDef, JobResult, Serializer, deserialize_job, serialize_job
+from .jobs import Deserializer, Job, JobDef, JobResult, Serializer, deserialize_job, deserialize_job_raw, serialize_job
 from .utils import timestamp_ms, to_ms, to_unix_ms
 
 logger = logging.getLogger('arq.connections')
@@ -170,7 +170,11 @@ class ArqRedis(BaseRedis):
                 await pipe.reset()
                 return None
 
-            enqueue_time_ms = timestamp_ms()
+            if _debounce and job_exists:
+                existing_job_data = await pipe.get(job_key)
+                _, _, _, _, enqueue_time_ms = deserialize_job_raw(existing_job_data, deserializer=self.job_deserializer)
+            else:
+                enqueue_time_ms = timestamp_ms()
             if _defer_until is not None:
                 score = to_unix_ms(_defer_until)
             elif defer_by_ms:

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -160,6 +160,7 @@ class ArqRedis(BaseRedis):
 
         defer_by_ms = to_ms(_defer_by)
         expires_ms = to_ms(_expires)
+        debounce_max_ms = to_ms(_debounce_max)
 
         async with self.pipeline(transaction=True) as pipe:
             await pipe.watch(job_key)
@@ -173,6 +174,9 @@ class ArqRedis(BaseRedis):
             if _debounce and job_exists:
                 existing_job_data = await pipe.get(job_key)
                 _, _, _, _, enqueue_time_ms = deserialize_job_raw(existing_job_data, deserializer=self.job_deserializer)
+                if debounce_max_ms is not None and timestamp_ms() - enqueue_time_ms >= debounce_max_ms:
+                    await pipe.reset()
+                    return None
             else:
                 enqueue_time_ms = timestamp_ms()
             if _defer_until is not None:

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -126,6 +126,8 @@ class ArqRedis(BaseRedis):
         _defer_by: Union[None, int, float, timedelta] = None,
         _expires: Union[None, int, float, timedelta] = None,
         _job_try: Optional[int] = None,
+        _debounce: bool = False,
+        _debounce_max: Union[None, int, float, timedelta] = None,
         **kwargs: Any,
     ) -> Optional[Job]:
         """
@@ -140,9 +142,15 @@ class ArqRedis(BaseRedis):
         :param _expires: do not start or retry a job after this duration;
             defaults to 24 hours plus deferring time, if any
         :param _job_try: useful when re-enqueueing jobs within a job
+        :param _debounce: if True and a queued job with the same ID exists, update its defer time
+            instead of returning None
+        :param _debounce_max: maximum total time from the original enqueue time before debouncing
+            stops and the job is allowed to run
         :param kwargs: any keyword arguments to pass to the function
         :return: :class:`arq.jobs.Job` instance or ``None`` if a job with this ID already exists
         """
+        if _debounce and not _job_id:
+            raise RuntimeError("'_debounce' requires '_job_id' to be set")
         if _queue_name is None:
             _queue_name = self.default_queue_name
         job_id = _job_id or uuid4().hex

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -163,7 +163,10 @@ class ArqRedis(BaseRedis):
 
         async with self.pipeline(transaction=True) as pipe:
             await pipe.watch(job_key)
-            if await pipe.exists(job_key, result_key_prefix + job_id):
+            job_exists = await pipe.exists(job_key)
+            result_exists = await pipe.exists(result_key_prefix + job_id)
+
+            if (job_exists or result_exists) and not (_debounce and job_exists and not result_exists):
                 await pipe.reset()
                 return None
 

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -13,7 +13,7 @@ from redis.asyncio.retry import Retry
 from redis.asyncio.sentinel import Sentinel
 from redis.exceptions import RedisError, WatchError
 
-from .constants import default_queue_name, expires_extra_ms, job_key_prefix, result_key_prefix
+from .constants import default_queue_name, expires_extra_ms, in_progress_key_prefix, job_key_prefix, result_key_prefix
 from .jobs import Deserializer, Job, JobDef, JobResult, Serializer, deserialize_job, deserialize_job_raw, serialize_job
 from .utils import timestamp_ms, to_ms, to_unix_ms
 
@@ -166,8 +166,11 @@ class ArqRedis(BaseRedis):
             await pipe.watch(job_key)
             job_exists = await pipe.exists(job_key)
             result_exists = await pipe.exists(result_key_prefix + job_id)
+            in_progress = await pipe.exists(in_progress_key_prefix + job_id) if _debounce else False
 
-            if (job_exists or result_exists) and not (_debounce and job_exists and not result_exists):
+            if (job_exists or result_exists) and not (
+                _debounce and job_exists and not result_exists and not in_progress
+            ):
                 await pipe.reset()
                 return None
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -321,6 +321,19 @@ async def test_debounce_preserves_enqueue_time(arq_redis: ArqRedis):
     assert info2.enqueue_time == info1.enqueue_time
 
 
+async def test_debounce_max_stops_debouncing(arq_redis: ArqRedis):
+    # given: a job enqueued with a very short debounce_max
+    j1 = await arq_redis.enqueue_job('foobar', _job_id='debounce_id', _defer_by=5)
+    assert isinstance(j1, Job)
+
+    # when: we wait longer than debounce_max and try to debounce
+    await asyncio.sleep(0.1)
+    j2 = await arq_redis.enqueue_job('foobar', _job_id='debounce_id', _debounce=True, _defer_by=10, _debounce_max=0.05)
+
+    # then: debounce is refused, returns None (let existing job run)
+    assert j2 is None
+
+
 async def test_enqueue_multiple(arq_redis: ArqRedis, caplog):
     caplog.set_level(logging.DEBUG)
     results = await asyncio.gather(*[arq_redis.enqueue_job('foobar', i, _job_id='testing') for i in range(10)])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -304,6 +304,23 @@ async def test_debounce_updates_defer_time(arq_redis: ArqRedis):
     assert score2 > score1
 
 
+async def test_debounce_preserves_enqueue_time(arq_redis: ArqRedis):
+    # given: a job enqueued
+    j1 = await arq_redis.enqueue_job('foobar', _job_id='debounce_id', _defer_by=5)
+    assert isinstance(j1, Job)
+    info1 = await j1.info()
+
+    await asyncio.sleep(0.05)
+
+    # when: debounced
+    j2 = await arq_redis.enqueue_job('foobar', _job_id='debounce_id', _debounce=True, _defer_by=10)
+    assert isinstance(j2, Job)
+    info2 = await j2.info()
+
+    # then: enqueue_time is preserved from the original job
+    assert info2.enqueue_time == info1.enqueue_time
+
+
 async def test_enqueue_multiple(arq_redis: ArqRedis, caplog):
     caplog.set_level(logging.DEBUG)
     results = await asyncio.gather(*[arq_redis.enqueue_job('foobar', i, _job_id='testing') for i in range(10)])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -289,6 +289,21 @@ async def test_debounce_requires_job_id(arq_redis: ArqRedis):
         await arq_redis.enqueue_job('foobar', _debounce=True)
 
 
+async def test_debounce_updates_defer_time(arq_redis: ArqRedis):
+    # given: a job already enqueued with a defer
+    j1 = await arq_redis.enqueue_job('foobar', _job_id='debounce_id', _defer_by=5)
+    assert isinstance(j1, Job)
+    score1 = await arq_redis.zscore(default_queue_name, 'debounce_id')
+
+    # when: we enqueue the same job with debounce and a new defer
+    j2 = await arq_redis.enqueue_job('foobar', _job_id='debounce_id', _debounce=True, _defer_by=10)
+
+    # then: the job is returned (not None) and the score is updated
+    assert isinstance(j2, Job)
+    score2 = await arq_redis.zscore(default_queue_name, 'debounce_id')
+    assert score2 > score1
+
+
 async def test_enqueue_multiple(arq_redis: ArqRedis, caplog):
     caplog.set_level(logging.DEBUG)
     results = await asyncio.gather(*[arq_redis.enqueue_job('foobar', i, _job_id='testing') for i in range(10)])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -283,6 +283,12 @@ async def test_get_jobs(arq_redis: ArqRedis):
     assert isinstance(jobs[2], JobDef)
 
 
+async def test_debounce_requires_job_id(arq_redis: ArqRedis):
+    # when
+    with pytest.raises(RuntimeError, match="'_debounce' requires '_job_id'"):
+        await arq_redis.enqueue_job('foobar', _debounce=True)
+
+
 async def test_enqueue_multiple(arq_redis: ArqRedis, caplog):
     caplog.set_level(logging.DEBUG)
     results = await asyncio.gather(*[arq_redis.enqueue_job('foobar', i, _job_id='testing') for i in range(10)])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -295,10 +295,12 @@ async def test_debounce_updates_defer_time(arq_redis: ArqRedis):
     assert isinstance(j1, Job)
     score1 = await arq_redis.zscore(default_queue_name, 'debounce_id')
 
-    # when: we enqueue the same job with debounce and a new defer
-    j2 = await arq_redis.enqueue_job('foobar', _job_id='debounce_id', _debounce=True, _defer_by=10)
+    await asyncio.sleep(0.05)
 
-    # then: the job is returned (not None) and the score is updated
+    # when: we enqueue the same job with debounce and the same defer
+    j2 = await arq_redis.enqueue_job('foobar', _job_id='debounce_id', _debounce=True, _defer_by=5)
+
+    # then: the job is returned (not None) and the score is updated (deferred from now)
     assert isinstance(j2, Job)
     score2 = await arq_redis.zscore(default_queue_name, 'debounce_id')
     assert score2 > score1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -334,6 +334,23 @@ async def test_debounce_max_stops_debouncing(arq_redis: ArqRedis):
     assert j2 is None
 
 
+async def test_debounce_does_not_touch_in_progress_job(arq_redis: ArqRedis):
+    # given: a job that is in progress (has in_progress key)
+    from arq.constants import in_progress_key_prefix
+
+    await arq_redis.enqueue_job('foobar', _job_id='debounce_id', _defer_by=5)
+    score_before = await arq_redis.zscore(default_queue_name, 'debounce_id')
+    await arq_redis.set(in_progress_key_prefix + 'debounce_id', b'1')
+
+    # when: we try to debounce
+    j2 = await arq_redis.enqueue_job('foobar', _job_id='debounce_id', _debounce=True, _defer_by=10)
+
+    # then: returns None, job score is unchanged
+    assert j2 is None
+    score_after = await arq_redis.zscore(default_queue_name, 'debounce_id')
+    assert score_after == score_before
+
+
 async def test_enqueue_multiple(arq_redis: ArqRedis, caplog):
     caplog.set_level(logging.DEBUG)
     results = await asyncio.gather(*[arq_redis.enqueue_job('foobar', i, _job_id='testing') for i in range(10)])


### PR DESCRIPTION
## Summary

- Add `_debounce` and `_debounce_max` parameters to `enqueue_job`
- When `_debounce=True`, re-enqueueing a job with the same `_job_id` resets its defer time instead of being silently dropped

## Design choices

### Debounce vs deduplication
The existing `_job_id` mechanism provides deduplication (at-most-once). Debounce is different — it pushes back execution each time a new call arrives, useful for coalescing bursts of events (e.g. user edits triggering a recomputation).

### `_debounce_max` to prevent starvation
Without a cap, a job could be debounced indefinitely and never run. `_debounce_max` sets a maximum window from the original enqueue time. Once exceeded, debounce calls are refused (`None` is returned) and the existing job runs on its current schedule.

### Preserving original `enqueue_time`
When debouncing, the serialized job keeps the original `enqueue_time_ms` rather than resetting it. This is necessary for `_debounce_max` to work, and it also reflects the true time the intent to run was first expressed.

### In-progress and completed jobs are never debounced
If a worker has already picked up the job (`in_progress_key_prefix` exists) or the job has a result, debounce returns `None`. This avoids overwriting a running job's data.

### Defer is relative to now
When debouncing with `_defer_by`, the new score is computed from the current time, not the original enqueue time. This matches the caller's intent of "run N seconds from now".

### Transaction safety
All checks and writes happen inside the existing `WATCH`/`MULTI`/`EXEC` pipeline, so concurrent debounce calls are safe — exactly one succeeds, others return `None` via `WatchError`.