### PR TITLE
fix: use pop() instead of del for job_tasks cleanup in run_job

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -601,7 +601,7 @@ class Worker:
             else:
                 result_str = '' if result is None or not self.log_results else truncate(repr(result))
             finally:
-                del self.job_tasks[job_id]
+                self.job_tasks.pop(job_id, None)
 
         except (Exception, asyncio.CancelledError) as e:
             finished_ms = timestamp_ms()


### PR DESCRIPTION
 The `finally` block in `Worker.run_job()` uses `del self.job_tasks[job_id]` (line 604) which raises `KeyError` if the entry was already removed.  This crashes the entire worker process, killing all concurrent in-flight jobs.

  ## The bug

  ```python
  # worker.py, run_job():
  try:
      self.job_tasks[job_id] = task = self.loop.create_task(...)
      try:
          result = await asyncio.wait_for(task, timeout_s)
      except (Exception, asyncio.CancelledError) as e:
          ...
          raise
      else:
          ...
      finally:
          del self.job_tasks[job_id]  # ← KeyError here crashes the worker

  except (Exception, asyncio.CancelledError) as e:
      ...
  ```

  The `finally` block always runs — even when the outer `except` catches an exception. If the `job_id` key was already removed from `self.job_tasks`
  (e.g. during cancellation handling), the `del` raises an unhandled `KeyError` that propagates up and kills the worker process.  With `max_jobs > 1`, this takes down all concurrent tasks on that worker, not just the one that triggered the error.

  ## Traceback

  ```
  File "arq/worker.py", line 604, in run_job
      del self.job_tasks[job_id]
  KeyError: 'metadata:01e23ac5-164f-4fd0-89da-2269220d839c:62983e7d'
  ```

  ## Fix
Replace `del self.job_tasks[job_id]` with `self.job_tasks.pop(job_id, None)`.  This is a no-op if the key is already gone, and identical behavior otherwise.  Cleanup code in `finally` blocks should be idempotent.