### PR TITLE
docs: show how to query a Job by id with a redis instance

### DIFF
--- a/docs/examples/job_by_id.py
+++ b/docs/examples/job_by_id.py
@@ -1,0 +1,26 @@
+import asyncio
+
+from arq import create_pool
+from arq.connections import RedisSettings
+from arq.jobs import Job
+
+
+async def main():
+    redis = await create_pool(RedisSettings())
+
+    # if the job_id is already known, instantiate Job directly to query it
+    job = Job(job_id='68362958a244465b9be909db4b7b5ab4', redis=redis)
+
+    print(await job.status())
+    """
+    >  JobStatus.not_found  (if no job with this id exists)
+    """
+
+    print(await job.info())
+    """
+    >  None  (if the job is absent or its key has expired)
+    """
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -151,6 +151,14 @@ You can access job information, status and job results using the :class:`arq.job
 
 .. literalinclude:: examples/job_results.py
 
+You can also access a job later if you already know its id by constructing a
+:class:`arq.jobs.Job` directly. You need to pass the ``job_id`` together with a
+redis instance (typically the same pool returned by :func:`arq.connections.create_pool`).
+If no job with that id exists, :func:`arq.jobs.Job.status` returns
+:attr:`arq.jobs.JobStatus.not_found`.
+
+.. literalinclude:: examples/job_by_id.py
+
 Retrying jobs and cancellation
 ..............................
 


### PR DESCRIPTION
Per samuelcolvin's note on #240: "yes it's very simple, you also need to pass a redis instance ... PR welcome to add this to the docs." Adds a short paragraph and an `examples/job_by_id.py` snippet under the existing "Job Results" section so users can look up a job from its id and see what happens when no such job exists (`JobStatus.not_found`).

Closes #240
